### PR TITLE
adding mock-server and BMC capture tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,12 @@ config.yml
 node_modules/
 package.json
 package-lock.json
+
+# Mock server test data
+tools/mock-server/testdata/
+tools/mock-server/server.crt
+tools/mock-server/server.key
+tools/mock-server/exporter-config.yml
+
+# Capture binary
+tools/capture/capture

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+.PHONY: build test mock-test capture clean help
+
+# Default target
+help:
+	@echo "Available targets:"
+	@echo "  build       - Build the redfish_exporter binary"
+	@echo "  test        - Run tests"
+	@echo "  mock-test   - Run mock server with exporter for testing"
+	@echo "  capture     - Capture Redfish data from a BMC"
+	@echo "  clean       - Clean build artifacts"
+	@echo ""
+	@echo "For mock-test, you can specify TESTDATA:"
+	@echo "  make mock-test TESTDATA=gb300/gb300_host.txt"
+	@echo ""
+	@echo "For capture, specify HOST, USER, PASS, and OUTPUT:"
+	@echo "  make capture HOST=10.0.0.1 USER=admin PASS=password OUTPUT=mysystem"
+
+# Build the exporter
+build:
+	go build -o redfish_exporter
+
+# Run tests
+test:
+	go test -v ./...
+
+# Run mock server and exporter for testing
+mock-test:
+	@if [ -z "$(TESTDATA)" ]; then \
+		echo "Using default test data: gb300/gb300_host.txt"; \
+		echo "You can specify different data with: make mock-test TESTDATA=<path>"; \
+		./tools/mock-server/test-local.sh gb300/gb300_host.txt; \
+	else \
+		./tools/mock-server/test-local.sh $(TESTDATA); \
+	fi
+
+# Build and run the capture tool
+capture:
+	@if [ -z "$(HOST)" ] || [ -z "$(USER)" ] || [ -z "$(PASS)" ] || [ -z "$(OUTPUT)" ]; then \
+		echo "Error: Required parameters missing"; \
+		echo "Usage: make capture HOST=<bmc-ip> USER=<username> PASS=<password> OUTPUT=<name>"; \
+		echo ""; \
+		echo "Optional parameters:"; \
+		echo "  TIMEOUT=30s      - Request timeout (default: 10s)"; \
+		echo "  SLEEP=100        - Sleep between requests in ms (default: 0)"; \
+		echo "  MAX=100          - Max endpoints to capture (default: unlimited)"; \
+		echo "  INSECURE=false   - Skip TLS verification (default: true)"; \
+		exit 1; \
+	fi
+	@echo "Building capture tool..."
+	@cd tools/capture && go build -o capture main.go
+	@echo "Capturing from $(HOST)..."
+	@cd tools/capture && ./capture \
+		-host $(HOST) \
+		-user $(USER) \
+		-pass $(PASS) \
+		-output $(OUTPUT) \
+		$(if $(TIMEOUT),-timeout $(TIMEOUT)) \
+		$(if $(SLEEP),-sleep $(SLEEP)) \
+		$(if $(MAX),-max $(MAX)) \
+		$(if $(filter false,$(INSECURE)),-insecure=false)
+	@echo ""
+	@echo "Capture complete! To test with mock server:"
+	@echo "  make mock-test TESTDATA=$(OUTPUT)/capture.txt"
+
+# Clean build artifacts
+clean:
+	rm -f redfish_exporter
+	rm -f tools/mock-server/exporter-config.yml
+	rm -f tools/capture/capture

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ To build the redfish_exporter executable run the command:
 
 ```sh
 go build
+# or
+make build
 ```
 
 There is also a Docker image available. The production build is handled by [gorelaser](https://goreleaser.com/) in order to build for multiple platforms.
@@ -107,6 +109,33 @@ You can then setup Prometheus to scrape the target using something like this in 
 
 Note that port 9610 has been [reserved][4] for the redfish_exporter.
 
+## Testing and Development
+
+### Mock Server
+
+We provide a mock Redfish server for testing the exporter without requiring actual hardware:
+
+```sh
+# Test with specific captured data
+make mock-test TESTDATA=my_system/capture.txt
+```
+
+This starts both a mock Redfish server (with HTTP and HTTPS support) and the exporter configured to scrape it.
+
+### Capturing Real Hardware Data
+
+To capture data from real hardware for testing:
+
+```sh
+# Capture Redfish responses from a BMC
+make capture HOST=10.0.0.100 USER=admin PASS=password OUTPUT=my_system
+
+# Then test with the captured data
+make mock-test TESTDATA=my_system/capture.txt
+```
+
+See `tools/mock-server/README.md` and `tools/capture/README.md` for detailed documentation.
+
 ## Supported Devices (tested)
 
 Prior to the fork (should also work now):
@@ -121,6 +150,7 @@ Prior to the fork (should also work now):
 Since the fork:
 
 - GIGABYTE R263-Z32 (AMI MegaRAC SP-X)
+- NVIDIA GB200 NVL
 
 ## Why a Fork?
 

--- a/tools/capture/README.md
+++ b/tools/capture/README.md
@@ -1,0 +1,122 @@
+# Redfish Capture Tool
+
+A tool to crawl and capture all Redfish endpoints from a BMC for use with the mock server.
+
+## Purpose
+
+This tool crawls a real Redfish-enabled BMC and saves all responses in a format that can be used by the mock server for testing. It performs a depth-first search following all `@odata.id` links to discover and capture the complete Redfish tree.
+
+## Installation
+
+```bash
+cd tools/capture
+go build -o capture main.go
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+./capture -host <bmc-ip> -user <username> -pass <password> -output <system_name>
+```
+
+### Examples
+
+```bash
+# Capture from a host you want to save as GB300
+./capture -host 10.0.0.100 -user admin -pass mypassword -output gb300
+
+# Capture only first 100 endpoints (useful for testing)
+./capture -host 10.0.0.100 -user admin -pass secret -output test_system -max 100
+```
+
+## Command-line Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `-host` | BMC host or IP address (required) | - |
+| `-user` | Username for authentication (required) | - |
+| `-pass` | Password for authentication (required) | - |
+| `-output` | Output directory name under testdata/ (required) | - |
+| `-insecure` | Skip TLS certificate verification | true |
+| `-timeout` | Per-request timeout | 10s |
+| `-sleep` | Sleep between requests in milliseconds | 0 |
+| `-max` | Maximum number of endpoints to capture (0 = unlimited) | 0 |
+
+## Output
+
+The tool creates a capture file at:
+```
+tools/mock-server/testdata/<output>/capture.txt
+```
+
+The format is compatible with the mock server:
+```
+# https://10.0.0.100/redfish/v1
+{
+  "@odata.id": "/redfish/v1",
+  "@odata.type": "#ServiceRoot.v1_15_0.ServiceRoot",
+  ...
+}
+# https://10.0.0.100/redfish/v1/Systems
+{
+  "@odata.id": "/redfish/v1/Systems",
+  ...
+}
+```
+
+## How It Works
+
+1. **Authentication**: Uses HTTP Basic Authentication to connect to the BMC
+2. **Discovery**: Starts from `/redfish/v1` and recursively discovers all endpoints
+3. **Crawling**: Uses depth-first search to explore the Redfish tree
+4. **Link Extraction**: Finds all `@odata.id` references in JSON responses
+5. **Filtering**:
+   - Skips `/Actions/` endpoints (POST-only)
+   - Stays on the same host
+   - Avoids duplicate visits
+
+## Testing with Mock Server
+
+After capturing data, you can test it with the mock server:
+
+```bash
+# 1. Capture data from a real BMC
+./capture -host 10.0.0.100 -user admin -pass password -output my_system
+
+# 2. Run mock server with captured data
+cd ../..  # Back to project root
+make mock-test TESTDATA=my_system/capture.txt
+
+# 3. The mock server will serve the captured data
+# and the exporter will be configured to scrape it
+```
+
+## Troubleshooting
+
+### Connection Refused
+- Verify the BMC IP and port are correct
+- Check if the BMC requires HTTPS (default) or HTTP
+- Ensure the BMC is accessible from your network
+
+### Authentication Failed
+- Verify username and password
+- Some BMCs have default credentials (check documentation)
+- Some BMCs lock accounts after failed attempts
+
+### TLS Certificate Errors
+- The `-insecure` flag is enabled by default
+- For production use, consider using proper certificates
+
+### Incomplete Capture
+- Increase timeout with `-timeout 30s` for slow BMCs
+- Add sleep between requests with `-sleep 100` if BMC has rate limiting
+- Check stderr output for specific endpoint errors
+
+## Notes
+
+- The tool respects the BMC's response time - slower BMCs will take longer to crawl
+- Large systems may have thousands of endpoints and take several minutes to capture
+- The capture file can be edited manually if needed to remove sensitive data
+- Captured data includes the full URL in comments for debugging

--- a/tools/capture/main.go
+++ b/tools/capture/main.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type Capture struct {
+	client      *http.Client
+	baseURL     string
+	outputPath  string
+	visited     map[string]bool
+	visitedMu   sync.Mutex
+	stack       []string
+	maxDocs     int
+	sleepMs     int
+	outputFile  *os.File
+	count       int
+	startTime   time.Time
+}
+
+func main() {
+	var (
+		host     = flag.String("host", "", "BMC host or IP address (required)")
+		username = flag.String("user", "", "Username (required)")
+		password = flag.String("pass", "", "Password (required)")
+		output   = flag.String("output", "", "Output directory name under testdata/ (required)")
+		insecure = flag.Bool("insecure", true, "Skip TLS certificate verification")
+		timeout  = flag.Duration("timeout", 10*time.Second, "Per-request timeout")
+		sleepMs  = flag.Int("sleep", 0, "Sleep between requests in milliseconds")
+		maxDocs  = flag.Int("max", 0, "Maximum number of documents to fetch (0 = unlimited)")
+	)
+	flag.Parse()
+
+	// Validate required flags
+	if *host == "" || *username == "" || *password == "" || *output == "" {
+		flag.Usage()
+		log.Fatal("Required flags: -host, -user, -pass, -output")
+	}
+
+	// Build base URL
+	baseURL := fmt.Sprintf("https://%s/redfish/v1", *host)
+	if !strings.Contains(*host, ":") && !strings.HasPrefix(*host, "http") {
+		// If no port specified and not a full URL, use default HTTPS
+		baseURL = fmt.Sprintf("https://%s/redfish/v1", *host)
+	} else if strings.HasPrefix(*host, "http") {
+		baseURL = fmt.Sprintf("%s/redfish/v1", strings.TrimSuffix(*host, "/"))
+	}
+
+	// Create output directory - relative to project root
+	// We're running from tools/capture, so go up two levels
+	outputDir := filepath.Join("..", "mock-server", "testdata", *output)
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		log.Fatalf("Failed to create output directory: %v", err)
+	}
+
+	// Open output file
+	outputPath := filepath.Join(outputDir, "capture.txt")
+	outputFile, err := os.Create(outputPath)
+	if err != nil {
+		log.Fatalf("Failed to create output file: %v", err)
+	}
+	defer outputFile.Close()
+
+	// Create HTTP client with basic auth
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: *insecure,
+		},
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   *timeout,
+	}
+
+	// Create capture instance
+	c := &Capture{
+		client:     client,
+		baseURL:    baseURL,
+		outputPath: outputPath,
+		visited:    make(map[string]bool),
+		stack:      []string{baseURL},
+		maxDocs:    *maxDocs,
+		sleepMs:    *sleepMs,
+		outputFile: outputFile,
+		startTime:  time.Now(),
+	}
+
+	// Set up basic auth
+	c.client.Transport = &authTransport{
+		username:  *username,
+		password:  *password,
+		transport: transport,
+	}
+
+	log.Printf("Connecting to %s...", *host)
+	log.Printf("Output will be saved to %s", outputPath)
+
+	// Start crawling
+	c.crawl()
+
+	duration := time.Since(c.startTime)
+	log.Printf("Captured %d endpoints in %v", c.count, duration)
+	log.Printf("Saved to %s", outputPath)
+}
+
+// authTransport adds basic auth to requests
+type authTransport struct {
+	username  string
+	password  string
+	transport http.RoundTripper
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.SetBasicAuth(t.username, t.password)
+	req.Header.Set("Accept", "application/json")
+	return t.transport.RoundTrip(req)
+}
+
+func (c *Capture) crawl() {
+	for len(c.stack) > 0 {
+		// Check max docs limit
+		if c.maxDocs > 0 && c.count >= c.maxDocs {
+			log.Printf("Reached maximum document limit (%d)", c.maxDocs)
+			break
+		}
+
+		// Pop URL from stack (DFS)
+		url := c.stack[len(c.stack)-1]
+		c.stack = c.stack[:len(c.stack)-1]
+
+		// Check if already visited
+		c.visitedMu.Lock()
+		if c.visited[url] {
+			c.visitedMu.Unlock()
+			continue
+		}
+		c.visited[url] = true
+		c.visitedMu.Unlock()
+
+		// Skip action endpoints
+		if strings.Contains(url, "/Actions/") {
+			continue
+		}
+
+		// Ensure same host
+		if !c.sameHost(url) {
+			continue
+		}
+
+		// Fetch the endpoint
+		c.count++
+		log.Printf("[%d/∞] Fetching %s", c.count, url)
+
+		doc, err := c.fetchJSON(url)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "# ERROR fetching %s: %v\n", url, err)
+			continue
+		}
+
+		// Write to output file
+		fmt.Fprintf(c.outputFile, "# %s\n", url)
+		encoder := json.NewEncoder(c.outputFile)
+		encoder.SetIndent("", "  ")
+		encoder.SetEscapeHTML(false)
+		if err := encoder.Encode(doc); err != nil {
+			fmt.Fprintf(os.Stderr, "# ERROR encoding JSON for %s: %v\n", url, err)
+			continue
+		}
+
+		// Extract and queue new links
+		links := c.extractODataLinks(doc)
+		for _, link := range links {
+			absURL := c.normalizeLink(link, url)
+			
+			c.visitedMu.Lock()
+			alreadyVisited := c.visited[absURL]
+			c.visitedMu.Unlock()
+			
+			if !alreadyVisited && c.sameHost(absURL) && !strings.Contains(absURL, "/Actions/") {
+				c.stack = append(c.stack, absURL)
+			}
+		}
+
+		// Sleep between requests if configured
+		if c.sleepMs > 0 {
+			time.Sleep(time.Duration(c.sleepMs) * time.Millisecond)
+		}
+	}
+}
+
+func (c *Capture) fetchJSON(urlStr string) (map[string]interface{}, error) {
+	resp, err := c.client.Get(urlStr)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	var doc map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return nil, err
+	}
+
+	return doc, nil
+}
+
+func (c *Capture) extractODataLinks(obj interface{}) []string {
+	var links []string
+	c.extractLinks(obj, &links)
+	return links
+}
+
+func (c *Capture) extractLinks(obj interface{}, links *[]string) {
+	switch v := obj.(type) {
+	case map[string]interface{}:
+		for key, value := range v {
+			if key == "@odata.id" {
+				if str, ok := value.(string); ok {
+					*links = append(*links, str)
+				}
+			} else {
+				c.extractLinks(value, links)
+			}
+		}
+	case []interface{}:
+		for _, item := range v {
+			c.extractLinks(item, links)
+		}
+	}
+}
+
+func (c *Capture) normalizeLink(link, baseURL string) string {
+	// If it's already an absolute URL, return as-is
+	if strings.HasPrefix(link, "http://") || strings.HasPrefix(link, "https://") {
+		return link
+	}
+
+	// Parse the base URL to get scheme and host
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return link
+	}
+
+	// Resolve the relative link
+	linkURL, err := url.Parse(link)
+	if err != nil {
+		return link
+	}
+
+	return base.ResolveReference(linkURL).String()
+}
+
+func (c *Capture) sameHost(urlStr string) bool {
+	baseURL, err := url.Parse(c.baseURL)
+	if err != nil {
+		return false
+	}
+	
+	checkURL, err := url.Parse(urlStr)
+	if err != nil {
+		return false
+	}
+	
+	return baseURL.Host == checkURL.Host
+}

--- a/tools/mock-server/README.md
+++ b/tools/mock-server/README.md
@@ -1,0 +1,187 @@
+# Redfish Mock Server
+
+A mock Redfish server for testing the redfish_exporter without needing actual hardware.
+
+## Purpose
+
+This tool allows you to:
+- Test the redfish_exporter against captured Redfish data
+- Debug issues without accessing production BMCs
+- Develop new features using real device responses
+- Validate compatibility with new hardware models
+- Test both HTTP and HTTPS connections with proper authentication
+
+## Quick Start
+
+### Easy Testing with Make
+
+The simplest way to test with mock data:
+
+```bash
+# From the project root directory:
+
+# Specify your test data
+make mock-test TESTDATA=my_system/capture.txt
+
+# Or run the script directly:
+./tools/mock-server/test-local.sh my_system/capture.txt
+```
+
+This will:
+- Start the mock server with both HTTP and HTTPS
+- Start the redfish_exporter configured to connect to the mock server
+- Display test commands you can use
+- Clean up everything when you press Ctrl+C
+
+## Detailed Usage
+
+### 1. Capture Redfish Data
+
+Place your captured data files in `tools/mock-server/testdata/<system_name>/`:
+
+```bash
+# The capture file format:
+# # https://bmc.example.com/redfish/v1
+# {JSON response}
+# # https://bmc.example.com/redfish/v1/Systems
+# {JSON response}
+```
+
+### 2. Run the Mock Server
+
+```bash
+# Basic usage - loads from testdata directory
+go run tools/mock-server/main.go -system gb300
+
+# With specific file
+go run tools/mock-server/main.go -file tools/mock-server/testdata/my_system/capture.txt
+
+# With HTTPS support (default ports: 8080 for HTTP, 8443 for HTTPS)
+go run tools/mock-server/main.go -file testdata.txt -https=true -http=true
+
+# With custom auth config
+go run tools/mock-server/main.go -file testdata.txt -auth auth.yml
+
+# With debug endpoint and response delay
+go run tools/mock-server/main.go -file testdata.txt -debug -delay 100ms
+```
+
+### 3. Authentication
+
+The mock server supports both Basic Auth and Session-based authentication.
+
+Default credentials (if no auth.yml provided):
+- Username: `admin`
+- Password: `password`
+
+Custom auth configuration (`auth.yml`):
+```yaml
+users:
+  - username: admin
+    password: password
+```
+
+### 4. Test with redfish_exporter
+
+The exporter configuration is automatically created by the test script, but you can also create it manually:
+
+```yaml
+# tools/mock-server/exporter-config.yml
+hosts:
+  default:
+    username: admin
+    password: password
+  localhost:8443:  # For HTTPS
+    username: admin
+    password: password
+  localhost:8080:  # For HTTP
+    username: admin
+    password: password
+loglevel: info
+```
+
+Then run:
+```bash
+# Run the exporter
+./redfish_exporter --config.file=tools/mock-server/exporter-config.yml
+
+# Test a scrape (HTTPS)
+curl "http://localhost:9610/redfish?target=localhost:8443"
+
+# Test a scrape (HTTP)
+curl "http://localhost:9610/redfish?target=localhost:8080"
+```
+
+## Debug Endpoint
+
+When running with `-debug`, you can access debug information:
+
+```bash
+curl http://localhost:8081/debug | jq .
+```
+
+This shows:
+- Total loaded endpoints
+- List of all available endpoints
+- Recent request history
+- Current configuration
+
+## Capture File Format
+
+The capture file should contain URL comments followed by JSON responses:
+
+```
+# https://10.0.0.1/redfish/v1
+{
+  "@odata.id": "/redfish/v1",
+  "@odata.type": "#ServiceRoot.v1_15_0.ServiceRoot",
+  ...
+}
+# https://10.0.0.1/redfish/v1/Systems
+{
+  "@odata.id": "/redfish/v1/Systems",
+  ...
+}
+```
+
+## Features
+
+- **HTTPS Support**: Runs on both HTTP and HTTPS with self-signed certificates
+- **Proper Authentication**:
+  - Basic Auth support
+  - Session-based authentication with X-Auth-Token
+  - Configurable credentials via auth.yml
+- **Flexible Data Loading**:
+  - Load from testdata directory structure (`-system` flag)
+  - Load specific files (`-file` flag)
+  - Automatic URL path extraction from capture files
+- **Developer Tools**:
+  - Debug endpoint for request inspection
+  - Request logging and tracking
+  - Response delay simulation
+  - Trailing slash handling
+- **Large file support**: Handles capture files with thousands of endpoints
+- **Error resilience**: Continues loading even if some endpoints have invalid JSON
+
+## Command-line Options
+
+```
+-file         Path to capture file containing Redfish responses
+-system       System name to load from testdata/<system>/
+-port         HTTP port (default: 8080)
+-https-port   HTTPS port (default: 8443)
+-http         Enable HTTP server (default: true)
+-https        Enable HTTPS server (default: true)
+-auth         Path to auth config file (default: uses admin/password)
+-cert         Path to TLS certificate file (auto-generated if not provided)
+-key          Path to TLS key file (auto-generated if not provided)
+-delay        Response delay to simulate network latency
+-debug        Enable debug endpoints
+-log          Path to access log file
+```
+
+## Limitations
+
+- No support for PATCH/POST operations beyond sessions
+- Static responses only (no dynamic behavior)
+- Self-signed certificates for HTTPS (certificate warnings expected)

--- a/tools/mock-server/auth.yml
+++ b/tools/mock-server/auth.yml
@@ -1,0 +1,6 @@
+# Authentication configuration for mock Redfish server
+# This file defines user accounts for Basic Auth and Session-based authentication
+
+users:
+  - username: admin
+    password: password

--- a/tools/mock-server/main.go
+++ b/tools/mock-server/main.go
@@ -1,0 +1,738 @@
+package main
+
+import (
+	"bufio"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/subtle"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+// MockRedfishServer provides a mock Redfish API server for testing
+type MockRedfishServer struct {
+	endpoints   map[string]json.RawMessage
+	mu          sync.RWMutex
+	config      *Config
+	accessLog   *log.Logger
+	requestLog  []RequestLog
+	reqLogMutex sync.RWMutex
+	authConfig  *AuthConfig
+	sessions    map[string]*Session
+	sessionMu   sync.RWMutex
+}
+
+// Config holds configuration for the mock server
+type Config struct {
+	DataFile        string            `json:"data_file"`
+	Port            string            `json:"port"`
+	HTTPSPort       string            `json:"https_port"`
+	ResponseDelay   time.Duration     `json:"response_delay"`
+	FailureRate     float64           `json:"failure_rate"`
+	CustomResponses map[string]string `json:"custom_responses"`
+	EnableLogging   bool              `json:"enable_logging"`
+	LogFile         string            `json:"log_file"`
+	AuthConfigFile  string            `json:"auth_config_file"`
+	CertFile        string            `json:"cert_file"`
+	KeyFile         string            `json:"key_file"`
+	EnableHTTPS     bool              `json:"enable_https"`
+	EnableHTTP      bool              `json:"enable_http"`
+}
+
+// AuthConfig holds authentication configuration
+type AuthConfig struct {
+	Users []User `yaml:"users"`
+}
+
+// User represents a user account
+type User struct {
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+}
+
+// Session represents an active session
+type Session struct {
+	ID        string
+	Username  string
+	Token     string
+	Created   time.Time
+	LastUsed  time.Time
+}
+
+// RequestLog tracks incoming requests for debugging
+type RequestLog struct {
+	Timestamp time.Time
+	Method    string
+	Path      string
+	Headers   map[string]string
+	Found     bool
+}
+
+func NewMockRedfishServer(config *Config) *MockRedfishServer {
+	server := &MockRedfishServer{
+		endpoints:  make(map[string]json.RawMessage),
+		config:     config,
+		requestLog: make([]RequestLog, 0),
+		sessions:   make(map[string]*Session),
+	}
+	
+	if config.EnableLogging && config.LogFile != "" {
+		logFile, err := os.OpenFile(config.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err == nil {
+			server.accessLog = log.New(logFile, "[ACCESS] ", log.LstdFlags)
+		}
+	}
+	
+	// Load auth config
+	if config.AuthConfigFile != "" {
+		if err := server.loadAuthConfig(config.AuthConfigFile); err != nil {
+			log.Printf("Warning: failed to load auth config, using defaults: %v", err)
+			server.useDefaultAuth()
+		}
+	} else {
+		server.useDefaultAuth()
+	}
+	
+	return server
+}
+
+func (s *MockRedfishServer) loadAuthConfig(filename string) error {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	
+	var authConfig AuthConfig
+	if err := yaml.Unmarshal(data, &authConfig); err != nil {
+		return err
+	}
+	
+	s.authConfig = &authConfig
+	log.Printf("Loaded %d users from auth config", len(authConfig.Users))
+	return nil
+}
+
+func (s *MockRedfishServer) useDefaultAuth() {
+	s.authConfig = &AuthConfig{
+		Users: []User{
+			{Username: "admin", Password: "password"},
+		},
+	}
+	log.Println("Using default authentication (admin/password)")
+}
+
+// LoadFromFile parses a capture file with format:
+// # URL
+// JSON content
+func (s *MockRedfishServer) LoadFromFile(filename string) error {
+	file, err := os.Open(filename)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	// Check file size
+	stat, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+	log.Printf("Loading file: %s (%.2f MB)", filename, float64(stat.Size())/(1024*1024))
+
+	reader := bufio.NewReader(file)
+	var currentURL string
+	var jsonLines []string
+	lineNum := 0
+	bracketCount := 0
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return fmt.Errorf("error reading file at line %d: %w", lineNum, err)
+		}
+		if err == io.EOF && line == "" {
+			break
+		}
+		lineNum++
+		
+		line = strings.TrimRight(line, "\n\r")
+		
+		// Check if this is a URL comment
+		if strings.HasPrefix(line, "# http") {
+			// Save previous endpoint if we have one
+			if currentURL != "" && len(jsonLines) > 0 {
+				if err := s.saveEndpoint(currentURL, jsonLines); err != nil {
+					log.Printf("Warning: failed to save endpoint %s: %v", currentURL, err)
+				}
+			}
+			
+			// Extract path from URL
+			currentURL = s.extractPath(line)
+			jsonLines = []string{}
+			bracketCount = 0
+		} else if currentURL != "" {
+			// Accumulate JSON lines
+			jsonLines = append(jsonLines, line)
+			
+			// Track brackets to know when JSON object is complete
+			bracketCount += strings.Count(line, "{") - strings.Count(line, "}")
+		}
+		
+		if lineNum%10000 == 0 {
+			log.Printf("Processed %d lines...", lineNum)
+		}
+	}
+	
+	// Save last endpoint
+	if currentURL != "" && len(jsonLines) > 0 {
+		if err := s.saveEndpoint(currentURL, jsonLines); err != nil {
+			log.Printf("Warning: failed to save endpoint %s: %v", currentURL, err)
+		}
+	}
+
+	log.Printf("Successfully loaded %d endpoints from %s", len(s.endpoints), filename)
+	return nil
+}
+
+func (s *MockRedfishServer) extractPath(urlLine string) string {
+	// Remove comment prefix and extract path
+	url := strings.TrimPrefix(urlLine, "# ")
+	url = strings.TrimSpace(url)
+	
+	// Find /redfish in the URL
+	idx := strings.Index(url, "/redfish")
+	if idx >= 0 {
+		return url[idx:]
+	}
+	
+	// If no /redfish found, try to extract path after host
+	parts := strings.Split(url, "/")
+	if len(parts) >= 4 { // https://host/path...
+		return "/" + strings.Join(parts[3:], "/")
+	}
+	
+	return url
+}
+
+func (s *MockRedfishServer) saveEndpoint(url string, jsonLines []string) error {
+	jsonStr := strings.Join(jsonLines, "\n")
+	jsonStr = strings.TrimSpace(jsonStr)
+	
+	if jsonStr == "" {
+		return nil
+	}
+	
+	// Validate JSON
+	var temp interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &temp); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.endpoints[url] = json.RawMessage(jsonStr)
+	
+	return nil
+}
+
+func (s *MockRedfishServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Log request
+	reqLog := RequestLog{
+		Timestamp: time.Now(),
+		Method:    r.Method,
+		Path:      r.URL.Path,
+		Headers:   make(map[string]string),
+		Found:     false,
+	}
+	
+	// Capture relevant headers
+	for key := range r.Header {
+		if strings.HasPrefix(key, "X-") || key == "Authorization" {
+			reqLog.Headers[key] = r.Header.Get(key)
+		}
+	}
+	
+	// Check authentication for non-public endpoints
+	if !s.isPublicEndpoint(r.URL.Path) && !s.isAuthenticated(r) {
+		w.Header().Set("WWW-Authenticate", `Basic realm="Redfish API"`)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		s.logRequest(reqLog)
+		return
+	}
+	
+	// Apply response delay if configured
+	if s.config.ResponseDelay > 0 {
+		time.Sleep(s.config.ResponseDelay)
+	}
+	
+	// Handle special endpoints
+	if s.handleSpecialEndpoints(w, r) {
+		reqLog.Found = true
+		s.logRequest(reqLog)
+		return
+	}
+	
+	// Look up the endpoint (handle trailing slash)
+	path := r.URL.Path
+	s.mu.RLock()
+	data, exists := s.endpoints[path]
+	if !exists && strings.HasSuffix(path, "/") {
+		// Try without trailing slash
+		path = strings.TrimSuffix(path, "/")
+		data, exists = s.endpoints[path]
+	}
+	s.mu.RUnlock()
+	
+	if !exists {
+		// Log miss and suggest alternatives
+		s.logMiss(r.URL.Path)
+		http.Error(w, fmt.Sprintf("Endpoint not found: %s", r.URL.Path), http.StatusNotFound)
+		s.logRequest(reqLog)
+		return
+	}
+	
+	reqLog.Found = true
+	
+	// Return the JSON data
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("OData-Version", "4.0")
+	w.WriteHeader(http.StatusOK)
+	w.Write(data)
+	
+	s.logRequest(reqLog)
+}
+
+func (s *MockRedfishServer) isPublicEndpoint(path string) bool {
+	publicPaths := []string{
+		"/redfish",
+		"/redfish/",
+		"/redfish/v1",
+		"/redfish/v1/",
+		"/redfish/v1/SessionService/Sessions",
+	}
+	for _, p := range publicPaths {
+		if path == p {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *MockRedfishServer) isAuthenticated(r *http.Request) bool {
+	// Check X-Auth-Token header
+	token := r.Header.Get("X-Auth-Token")
+	if token != "" {
+		s.sessionMu.RLock()
+		session, exists := s.sessions[token]
+		s.sessionMu.RUnlock()
+		
+		if exists {
+			// Update last used time
+			s.sessionMu.Lock()
+			session.LastUsed = time.Now()
+			s.sessionMu.Unlock()
+			return true
+		}
+	}
+	
+	// Check Basic Auth
+	auth := r.Header.Get("Authorization")
+	if strings.HasPrefix(auth, "Basic ") {
+		credentials := strings.TrimPrefix(auth, "Basic ")
+		decoded, err := base64.StdEncoding.DecodeString(credentials)
+		if err != nil {
+			return false
+		}
+		
+		parts := strings.SplitN(string(decoded), ":", 2)
+		if len(parts) != 2 {
+			return false
+		}
+		
+		username, password := parts[0], parts[1]
+		return s.validateCredentials(username, password)
+	}
+	
+	return false
+}
+
+func (s *MockRedfishServer) validateCredentials(username, password string) bool {
+	for _, user := range s.authConfig.Users {
+		if subtle.ConstantTimeCompare([]byte(user.Username), []byte(username)) == 1 &&
+		   subtle.ConstantTimeCompare([]byte(user.Password), []byte(password)) == 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *MockRedfishServer) handleSpecialEndpoints(w http.ResponseWriter, r *http.Request) bool {
+	// Handle authentication
+	if r.URL.Path == "/redfish/v1/SessionService/Sessions" && r.Method == "POST" {
+		// Parse credentials from request body
+		var loginReq struct {
+			UserName string `json:"UserName"`
+			Password string `json:"Password"`
+		}
+		
+		if err := json.NewDecoder(r.Body).Decode(&loginReq); err != nil {
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return true
+		}
+		
+		// Validate credentials
+		if !s.validateCredentials(loginReq.UserName, loginReq.Password) {
+			http.Error(w, "Invalid credentials", http.StatusUnauthorized)
+			return true
+		}
+		
+		// Create session
+		sessionID := fmt.Sprintf("%d", time.Now().UnixNano())
+		token := "token-" + sessionID
+		session := &Session{
+			ID:       sessionID,
+			Username: loginReq.UserName,
+			Token:    token,
+			Created:  time.Now(),
+			LastUsed: time.Now(),
+		}
+		
+		s.sessionMu.Lock()
+		s.sessions[token] = session
+		s.sessionMu.Unlock()
+		
+		response := map[string]interface{}{
+			"@odata.id":   "/redfish/v1/SessionService/Sessions/" + sessionID,
+			"@odata.type": "#Session.v1_0_0.Session",
+			"Id":          sessionID,
+			"Name":        "User Session",
+			"UserName":    loginReq.UserName,
+			"Created":     session.Created.Format(time.RFC3339),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Auth-Token", token)
+		w.Header().Set("Location", "/redfish/v1/SessionService/Sessions/"+sessionID)
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(response)
+		return true
+	}
+	
+	// Handle logout
+	if strings.HasPrefix(r.URL.Path, "/redfish/v1/SessionService/Sessions/") && r.Method == "DELETE" {
+		// Remove session if it exists
+		token := r.Header.Get("X-Auth-Token")
+		if token != "" {
+			s.sessionMu.Lock()
+			delete(s.sessions, token)
+			s.sessionMu.Unlock()
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return true
+	}
+	
+	return false
+}
+
+func (s *MockRedfishServer) logRequest(reqLog RequestLog) {
+	s.reqLogMutex.Lock()
+	s.requestLog = append(s.requestLog, reqLog)
+	if len(s.requestLog) > 1000 { // Keep last 1000 requests
+		s.requestLog = s.requestLog[1:]
+	}
+	s.reqLogMutex.Unlock()
+	
+	status := "FOUND"
+	if !reqLog.Found {
+		status = "NOT_FOUND"
+	}
+	
+	if s.accessLog != nil {
+		s.accessLog.Printf("%s %s %s", reqLog.Method, reqLog.Path, status)
+	}
+	
+	log.Printf("[%s] %s %s", status, reqLog.Method, reqLog.Path)
+}
+
+func (s *MockRedfishServer) logMiss(path string) {
+	log.Printf("Endpoint not found: %s", path)
+	
+	// Suggest similar endpoints
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	
+	suggestions := []string{}
+	pathParts := strings.Split(path, "/")
+	
+	for endpoint := range s.endpoints {
+		endpointParts := strings.Split(endpoint, "/")
+		
+		// Check for similar paths
+		if len(pathParts) > 2 && len(endpointParts) > 2 {
+			if pathParts[2] == endpointParts[2] { // Same main resource
+				suggestions = append(suggestions, endpoint)
+				if len(suggestions) >= 5 {
+					break
+				}
+			}
+		}
+	}
+	
+	if len(suggestions) > 0 {
+		log.Println("Similar endpoints available:")
+		for _, s := range suggestions {
+			log.Printf("  - %s", s)
+		}
+	}
+}
+
+// GetRequestLog returns recent request logs for debugging
+func (s *MockRedfishServer) GetRequestLog() []RequestLog {
+	s.reqLogMutex.RLock()
+	defer s.reqLogMutex.RUnlock()
+	
+	logs := make([]RequestLog, len(s.requestLog))
+	copy(logs, s.requestLog)
+	return logs
+}
+
+// DebugHandler provides debug information about the mock server
+func (s *MockRedfishServer) DebugHandler(w http.ResponseWriter, r *http.Request) {
+	s.mu.RLock()
+	endpoints := make([]string, 0, len(s.endpoints))
+	for endpoint := range s.endpoints {
+		endpoints = append(endpoints, endpoint)
+	}
+	s.mu.RUnlock()
+	
+	response := map[string]interface{}{
+		"total_endpoints": len(endpoints),
+		"endpoints":       endpoints,
+		"recent_requests": s.GetRequestLog(),
+		"config":          s.config,
+	}
+	
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+}
+
+func main() {
+	var (
+		dataFile   = flag.String("file", "", "Path to the capture file containing Redfish responses")
+		dataDir    = flag.String("dir", "", "Directory containing multiple capture files")
+		system     = flag.String("system", "", "System name to load from testdata/<system>/")
+		port       = flag.String("port", "8080", "Port to listen on (HTTP)")
+		httpsPort  = flag.String("https-port", "8443", "Port to listen on (HTTPS)")
+		delay      = flag.Duration("delay", 0, "Response delay to simulate network latency")
+		logFile    = flag.String("log", "", "Path to access log file")
+		authConfig = flag.String("auth", "", "Path to auth config file (default: use admin/password)")
+		certFile   = flag.String("cert", "", "Path to TLS certificate file (auto-generated if not provided)")
+		keyFile    = flag.String("key", "", "Path to TLS key file (auto-generated if not provided)")
+		enableHTTP = flag.Bool("http", true, "Enable HTTP server")
+		enableHTTPS = flag.Bool("https", true, "Enable HTTPS server")
+		debug      = flag.Bool("debug", false, "Enable debug endpoints")
+	)
+	flag.Parse()
+	
+	// Determine data source
+	var dataSource string
+	if *system != "" {
+		// Load from testdata/<system>/ directory
+		testdataPath := filepath.Join("tools", "mock-server", "testdata", *system)
+		files, err := filepath.Glob(filepath.Join(testdataPath, "*.txt"))
+		if err != nil || len(files) == 0 {
+			log.Fatalf("No data files found in %s", testdataPath)
+		}
+		dataSource = files[0] // Use first .txt file found
+		log.Printf("Loading system '%s' from %s", *system, dataSource)
+	} else if *dataFile != "" {
+		dataSource = *dataFile
+	} else if *dataDir == "" {
+		log.Fatal("Please specify either -file, -dir, or -system flag")
+	}
+	
+	config := &Config{
+		Port:           *port,
+		HTTPSPort:      *httpsPort,
+		ResponseDelay:  *delay,
+		EnableLogging:  *logFile != "",
+		LogFile:        *logFile,
+		AuthConfigFile: *authConfig,
+		CertFile:       *certFile,
+		KeyFile:        *keyFile,
+		EnableHTTP:     *enableHTTP,
+		EnableHTTPS:    *enableHTTPS,
+	}
+	
+	server := NewMockRedfishServer(config)
+	
+	// Load data
+	if dataSource != "" {
+		if err := server.LoadFromFile(dataSource); err != nil {
+			log.Fatalf("Failed to load data from file: %v", err)
+		}
+	}
+	
+	if *dataDir != "" {
+		files, err := filepath.Glob(filepath.Join(*dataDir, "*.txt"))
+		if err != nil {
+			log.Fatalf("Failed to find files in directory: %v", err)
+		}
+		for _, file := range files {
+			log.Printf("Loading %s...", file)
+			if err := server.LoadFromFile(file); err != nil {
+				log.Printf("Warning: failed to load %s: %v", file, err)
+			}
+		}
+	}
+	
+	// Set up HTTP server
+	mux := http.NewServeMux()
+	mux.Handle("/redfish/", server)
+	
+	if *debug {
+		mux.HandleFunc("/debug", server.DebugHandler)
+		log.Println("Debug endpoint available at /debug")
+	}
+	
+	// Generate or load certificates for HTTPS
+	var tlsConfig *tls.Config
+	if config.EnableHTTPS {
+		var err error
+		tlsConfig, err = getTLSConfig(config)
+		if err != nil {
+			log.Fatalf("Failed to set up TLS: %v", err)
+		}
+	}
+	
+	// Start servers
+	var wg sync.WaitGroup
+	
+	if config.EnableHTTP {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			addr := ":" + config.Port
+			log.Printf("Starting HTTP mock Redfish server on %s", addr)
+			if *debug {
+				log.Printf("Debug info available at: http://localhost:%s/debug", config.Port)
+			}
+			log.Fatal(http.ListenAndServe(addr, mux))
+		}()
+	}
+	
+	if config.EnableHTTPS {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			addr := ":" + config.HTTPSPort
+			log.Printf("Starting HTTPS mock Redfish server on %s", addr)
+			if *debug {
+				log.Printf("Debug info available at: https://localhost:%s/debug", config.HTTPSPort)
+			}
+			server := &http.Server{
+				Addr:      addr,
+				Handler:   mux,
+				TLSConfig: tlsConfig,
+			}
+			log.Fatal(server.ListenAndServeTLS("", ""))
+		}()
+	}
+	
+	log.Printf("Configure redfish_exporter to scrape:")
+	if config.EnableHTTP {
+		log.Printf("  HTTP:  localhost:%s", config.Port)
+	}
+	if config.EnableHTTPS {
+		log.Printf("  HTTPS: localhost:%s (with insecure TLS)", config.HTTPSPort)
+	}
+	
+	wg.Wait()
+}
+
+// getTLSConfig returns TLS configuration with certificate
+func getTLSConfig(config *Config) (*tls.Config, error) {
+	var cert tls.Certificate
+	var err error
+	
+	if config.CertFile != "" && config.KeyFile != "" {
+		// Load existing certificate
+		cert, err = tls.LoadX509KeyPair(config.CertFile, config.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load certificate: %w", err)
+		}
+		log.Printf("Using existing certificate from %s", config.CertFile)
+	} else {
+		// Generate self-signed certificate
+		cert, err = generateSelfSignedCert()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate certificate: %w", err)
+		}
+		log.Println("Generated self-signed certificate")
+	}
+	
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}, nil
+}
+
+// generateSelfSignedCert creates a self-signed certificate for testing
+func generateSelfSignedCert() (tls.Certificate, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Mock Redfish Server"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.IPv4(127, 0, 0, 1)},
+		DNSNames:              []string{"localhost"},
+	}
+	
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	
+	// Save certificate and key to files for reuse
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	
+	// Optionally save to files
+	certPath := "tools/mock-server/server.crt"
+	keyPath := "tools/mock-server/server.key"
+	
+	if err := ioutil.WriteFile(certPath, certPEM, 0644); err != nil {
+		log.Printf("Warning: failed to save certificate to %s: %v", certPath, err)
+	}
+	if err := ioutil.WriteFile(keyPath, keyPEM, 0600); err != nil {
+		log.Printf("Warning: failed to save key to %s: %v", keyPath, err)
+	}
+	
+	return tls.X509KeyPair(certPEM, keyPEM)
+}

--- a/tools/mock-server/test-local.sh
+++ b/tools/mock-server/test-local.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# Script to run mock-server and redfish_exporter together for local testing
+# Run from the top-level redfish_exporter directory
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check arguments
+if [ $# -eq 0 ]; then
+    echo -e "${RED}Usage: $0 <testdata_file>${NC}"
+    echo -e "Example: $0 gb300/gb300_host.txt"
+    exit 1
+fi
+
+# Configuration
+TESTDATA_FILE=$1
+MOCK_HTTP_PORT=${MOCK_HTTP_PORT:-8080}
+MOCK_HTTPS_PORT=${MOCK_HTTPS_PORT:-8443}
+EXPORTER_PORT=${EXPORTER_PORT:-9610}
+USE_HTTPS=${USE_HTTPS:-true}
+MOCK_PID=""
+EXPORTER_PID=""
+
+# Cleanup function
+cleanup() {
+    echo -e "\n${YELLOW}Shutting down services...${NC}"
+    if [ ! -z "$MOCK_PID" ]; then
+        kill $MOCK_PID 2>/dev/null || true
+        echo "Mock server stopped"
+    fi
+    if [ ! -z "$EXPORTER_PID" ]; then
+        kill $EXPORTER_PID 2>/dev/null || true
+        echo "Redfish exporter stopped"
+    fi
+    exit 0
+}
+
+# Set up trap for cleanup
+trap cleanup INT TERM
+
+# Check if test data file exists
+if [ ! -f "tools/mock-server/testdata/${TESTDATA_FILE}" ]; then
+    echo -e "${RED}Error: Test data file not found at tools/mock-server/testdata/${TESTDATA_FILE}${NC}"
+    echo "Available test data files:"
+    find tools/mock-server/testdata -name "*.txt" -type f 2>/dev/null || echo "  None found"
+    exit 1
+fi
+
+# Build the redfish_exporter if it doesn't exist
+if [ ! -f "./redfish_exporter" ]; then
+    echo -e "${YELLOW}Building redfish_exporter...${NC}"
+    go build
+fi
+
+# Create exporter config file
+echo -e "${GREEN}Creating exporter config file...${NC}"
+if [ "$USE_HTTPS" = "true" ]; then
+    TARGET_PORT=$MOCK_HTTPS_PORT
+else
+    TARGET_PORT=$MOCK_HTTP_PORT
+fi
+
+cat > tools/mock-server/exporter-config.yml <<EOF
+# Configuration for redfish_exporter to connect to mock server
+hosts:
+  default:
+    username: admin
+    password: password
+  localhost:${TARGET_PORT}:
+    username: admin
+    password: password
+groups:
+  mock_servers:
+    username: admin
+    password: password
+loglevel: info
+EOF
+
+# Check if using HTTPS
+if [ "$USE_HTTPS" = "true" ]; then
+    echo -e "${GREEN}Using HTTPS mode with self-signed certificates${NC}"
+    echo -e "${YELLOW}Note: The exporter will connect using HTTPS with InsecureSkipVerify${NC}"
+else
+    echo -e "${YELLOW}Using HTTP mode${NC}"
+    echo -e "${YELLOW}Note: You need to modify collector/redfish_collector.go line 108 to use http:// instead of https://${NC}"
+    echo -e "${YELLOW}Change: url := fmt.Sprintf(\"https://%s\", host)${NC}"
+    echo -e "${YELLOW}To:     url := fmt.Sprintf(\"http://%s\", host)${NC}"
+    read -p "Have you made this change? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo -e "${RED}Please make the change and run this script again${NC}"
+        exit 1
+    fi
+fi
+
+# Start mock server
+echo -e "\n${GREEN}Starting mock server with ${TESTDATA_FILE}...${NC}"
+if [ "$USE_HTTPS" = "true" ]; then
+    echo -e "${GREEN}  HTTP on port ${MOCK_HTTP_PORT}, HTTPS on port ${MOCK_HTTPS_PORT}${NC}"
+    go run tools/mock-server/main.go \
+        -file tools/mock-server/testdata/${TESTDATA_FILE} \
+        -auth tools/mock-server/auth.yml \
+        -port ${MOCK_HTTP_PORT} \
+        -https-port ${MOCK_HTTPS_PORT} \
+        -http=true \
+        -https=true \
+        -debug &
+else
+    echo -e "${GREEN}  HTTP only on port ${MOCK_HTTP_PORT}${NC}"
+    go run tools/mock-server/main.go \
+        -file tools/mock-server/testdata/${TESTDATA_FILE} \
+        -auth tools/mock-server/auth.yml \
+        -port ${MOCK_HTTP_PORT} \
+        -http=true \
+        -https=false \
+        -debug &
+fi
+MOCK_PID=$!
+
+# Wait for mock server to be ready
+echo -e "${YELLOW}Waiting for mock server to be ready...${NC}"
+for i in {1..15}; do
+    if [ "$USE_HTTPS" = "true" ]; then
+        if curl -s -f -k -u admin:password https://localhost:${MOCK_HTTPS_PORT}/redfish/v1 > /dev/null 2>&1; then
+            echo -e "${GREEN}Mock server is ready!${NC}"
+            break
+        fi
+    else
+        if curl -s -f -u admin:password http://localhost:${MOCK_HTTP_PORT}/redfish/v1 > /dev/null 2>&1; then
+            echo -e "${GREEN}Mock server is ready!${NC}"
+            break
+        fi
+    fi
+    sleep 1
+done
+
+# Start redfish_exporter
+echo -e "\n${GREEN}Starting redfish_exporter on port ${EXPORTER_PORT}...${NC}"
+./redfish_exporter --config.file=tools/mock-server/exporter-config.yml &
+EXPORTER_PID=$!
+
+# Wait for exporter to be ready
+echo -e "${YELLOW}Waiting for exporter to be ready...${NC}"
+for i in {1..10}; do
+    if curl -s -f http://localhost:${EXPORTER_PORT}/metrics > /dev/null 2>&1; then
+        echo -e "${GREEN}Exporter is ready!${NC}"
+        break
+    fi
+    sleep 1
+done
+
+# Print usage instructions
+echo -e "\n${GREEN}=== Services Running ===${NC}"
+if [ "$USE_HTTPS" = "true" ]; then
+    echo -e "Mock Server HTTP:   http://localhost:${MOCK_HTTP_PORT}"
+    echo -e "Mock Server HTTPS:  https://localhost:${MOCK_HTTPS_PORT} (self-signed cert)"
+    echo -e "Mock Server Debug:  http://localhost:${MOCK_HTTP_PORT}/debug"
+    echo -e "Exporter:           http://localhost:${EXPORTER_PORT}"
+    echo -e ""
+    echo -e "${GREEN}=== Test Commands ===${NC}"
+    echo -e "Test scrape:        ${YELLOW}curl 'http://localhost:${EXPORTER_PORT}/redfish?target=localhost:${MOCK_HTTPS_PORT}'${NC}"
+    echo -e "Test with group:    ${YELLOW}curl 'http://localhost:${EXPORTER_PORT}/redfish?target=localhost:${MOCK_HTTPS_PORT}&group=mock_servers'${NC}"
+    echo -e "Check mock auth:    ${YELLOW}curl -k -u admin:password https://localhost:${MOCK_HTTPS_PORT}/redfish/v1/Systems${NC}"
+    echo -e "View debug info:    ${YELLOW}curl http://localhost:${MOCK_HTTP_PORT}/debug | jq .${NC}"
+else
+    echo -e "Mock Server:        http://localhost:${MOCK_HTTP_PORT}"
+    echo -e "Mock Server Debug:  http://localhost:${MOCK_HTTP_PORT}/debug"
+    echo -e "Exporter:           http://localhost:${EXPORTER_PORT}"
+    echo -e ""
+    echo -e "${GREEN}=== Test Commands ===${NC}"
+    echo -e "Test scrape:        ${YELLOW}curl 'http://localhost:${EXPORTER_PORT}/redfish?target=localhost:${MOCK_HTTP_PORT}'${NC}"
+    echo -e "Test with group:    ${YELLOW}curl 'http://localhost:${EXPORTER_PORT}/redfish?target=localhost:${MOCK_HTTP_PORT}&group=mock_servers'${NC}"
+    echo -e "Check mock auth:    ${YELLOW}curl -u admin:password http://localhost:${MOCK_HTTP_PORT}/redfish/v1/Systems${NC}"
+    echo -e "View debug info:    ${YELLOW}curl http://localhost:${MOCK_HTTP_PORT}/debug | jq .${NC}"
+fi
+echo -e ""
+echo -e "${YELLOW}Press Ctrl+C to stop all services${NC}"
+
+# Keep script running
+wait


### PR DESCRIPTION
### Add Mock Server and Capture Tool for Local Testing
This PR adds comprehensive local testing infrastructure for the redfish_exporter, enabling development and testing without requiring access to physical hardware.

#### New Features
**Mock Redfish Server** (`tools/mock-server/`)
  - Serves captured Redfish API responses for testing
  - Supports both HTTP (8080) and HTTPS (8443) with self-signed certificates
  - Implements proper authentication (Basic Auth and Session-based)
  - Loads test data from `testdata/<system_name>/` structure
  - Includes debug endpoint for request inspection

**Capture Tool** (`tools/capture/`)
  - Crawls real Redfish BMCs to capture API responses
  - Uses depth-first search to discover all endpoints
  - Outputs in mock server-compatible format
  - Configurable timeout, rate limiting, and max endpoints

**Easy Testing Workflow**
  - `make capture HOST=10.0.0.1 USER=admin PASS=pwd OUTPUT=mysystem` - Capture from real hardware
  - `make mock-test TESTDATA=mysystem/capture.txt` - Test with captured data

#### Changes
  - Added mock server with HTTPS and auth support
  - Added capture tool for harvesting Redfish data
  - Created convenience Makefile targets
  - Updated .gitignore for test data and generated files
  - Updated README with testing documentation