### PR TITLE
adding redfish_system_processor_health_rollup metric

### DIFF
--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -59,6 +59,7 @@ func createSystemMetricMap() map[string]Metric {
 
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_state", fmt.Sprintf("system processor state,%s", CommonStateHelp), SystemProcessorLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_health_state", fmt.Sprintf("system processor health state,%s", CommonHealthHelp), SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_health_rollup", fmt.Sprintf("system processor health rollup,%s", CommonHealthHelp), SystemProcessorLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_total_threads", "system processor total threads", SystemProcessorLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_total_cores", "system processor total cores", SystemProcessorLabelNames)
 
@@ -352,6 +353,7 @@ func parseProcessor(ch chan<- prometheus.Metric, systemHostName string, processo
 	processorTotalThreads := processor.TotalThreads
 	processorState := processor.Status.State
 	processorHelathState := processor.Status.Health
+	processorHealthRollup := processor.Status.HealthRollup
 
 	systemProcessorLabelValues := []string{systemHostName, "processor", processorName, processorID}
 
@@ -360,6 +362,9 @@ func parseProcessor(ch chan<- prometheus.Metric, systemHostName string, processo
 	}
 	if processorHelathStateValue, ok := parseCommonStatusHealth(processorHelathState); ok {
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_health_state"].desc, prometheus.GaugeValue, processorHelathStateValue, systemProcessorLabelValues...)
+	}
+	if processorHealthRollupValue, ok := parseCommonStatusHealth(processorHealthRollup); ok {
+		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_health_rollup"].desc, prometheus.GaugeValue, processorHealthRollupValue, systemProcessorLabelValues...)
 	}
 	ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_total_threads"].desc, prometheus.GaugeValue, float64(processorTotalThreads), systemProcessorLabelValues...)
 	ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_total_cores"].desc, prometheus.GaugeValue, float64(processorTotalCores), systemProcessorLabelValues...)


### PR DESCRIPTION
Summary
- Added redfish_system_processor_health_rollup metric to track aggregated health of processors and their subsystems
- Complements existing processor_health_state metric which only tracks direct processor health

Why
- GPU processors have multiple subsystems (memory, thermal, power, PCIe). HealthRollup provides a single metric that reports the worst-case health across all subsystems, enabling better monitoring of overall GPU health.

Changes
- Modified collector/system_collector.go to collect Status.HealthRollup from processor objects
- Added metric definition with proper Prometheus type and help text

Testing
- Verified new metric collects successfully for GPU processors on GB300 mock server.

```
# HELP redfish_system_processor_health_rollup system processor health rollup,1(OK),2(Warning),3(Critical)
# TYPE redfish_system_processor_health_rollup gauge
redfish_system_processor_health_rollup{hostname="",processor="Processor",processor_id="GPU_0",resource="processor"} 1
redfish_system_processor_health_rollup{hostname="",processor="Processor",processor_id="GPU_1",resource="processor"} 1
redfish_system_processor_health_rollup{hostname="",processor="Processor",processor_id="GPU_2",resource="processor"} 1
redfish_system_processor_health_rollup{hostname="",processor="Processor",processor_id="GPU_3",resource="processor"} 1
```