### PR TITLE
adding in chassis health rollup metrics

### DIFF
--- a/collector/chassis_collector.go
+++ b/collector/chassis_collector.go
@@ -41,6 +41,7 @@ type ChassisCollector struct {
 func createChassisMetricMap() map[string]Metric {
 	chassisMetrics := make(map[string]Metric)
 	addToMetricMap(chassisMetrics, ChassisSubsystem, "health", fmt.Sprintf("health of chassis,%s", CommonHealthHelp), ChassisLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "health_rollup", fmt.Sprintf("health rollup of chassis,%s", CommonHealthHelp), ChassisLabelNames)
 	addToMetricMap(chassisMetrics, ChassisSubsystem, "state", fmt.Sprintf("state of chassis,%s", CommonStateHelp), ChassisLabelNames)
 	addToMetricMap(chassisMetrics, ChassisSubsystem, "model_info", "organization responsible for producing the chassis, the name by which the manufacturer generally refers to the chassis, and a part number and sku assigned by the organization that is responsible for producing or manufacturing the chassis", ChassisModel)
 
@@ -133,9 +134,13 @@ func (c *ChassisCollector) Collect(ch chan<- prometheus.Metric) {
 			chassisStatus := chassis.Status
 			chassisStatusState := chassisStatus.State
 			chassisStatusHealth := chassisStatus.Health
+			chassisStatusHealthRollup := chassisStatus.HealthRollup
 			ChassisLabelValues := []string{"chassis", chassisID}
 			if chassisStatusHealthValue, ok := parseCommonStatusHealth(chassisStatusHealth); ok {
 				ch <- prometheus.MustNewConstMetric(c.metrics["chassis_health"].desc, prometheus.GaugeValue, chassisStatusHealthValue, ChassisLabelValues...)
+			}
+			if chassisStatusHealthRollupValue, ok := parseCommonStatusHealth(chassisStatusHealthRollup); ok {
+				ch <- prometheus.MustNewConstMetric(c.metrics["chassis_health_rollup"].desc, prometheus.GaugeValue, chassisStatusHealthRollupValue, ChassisLabelValues...)
 			}
 			if chassisStatusStateValue, ok := parseCommonStatusState(chassisStatusState); ok {
 				ch <- prometheus.MustNewConstMetric(c.metrics["chassis_state"].desc, prometheus.GaugeValue, chassisStatusStateValue, ChassisLabelValues...)


### PR DESCRIPTION
Add HealthRollup Metrics for Chassis

Summary
- Added redfish_chassis_health_rollup metrics

Why
- Single metric to monitor overall component health including all subsystems - critical for FPGA monitoring where subsystem failures may not be reflected in direct health status

Changes
- collector/chassis_collector.go: Added chassis HealthRollup collection

Testing
- Verified new metric collects successfully for FPGA chassis on GB300 mock server.
```
# HELP redfish_chassis_health_rollup health rollup of chassis,1(OK),2(Warning),3(Critical)
# TYPE redfish_chassis_health_rollup gauge
redfish_chassis_health_rollup{chassis_id="BMC_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="CBC_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="CBC_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="CBC_2",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="CBC_3",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="CPLD_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="CPLD_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="Chassis_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_BMC_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_CPLD_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_CPU_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_CPU_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_Chassis_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_ERoT_BMC_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_ERoT_CPU_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_ERoT_CPU_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_ERoT_FPGA_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_ERoT_FPGA_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_FPGA_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_FPGA_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_GPU_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_GPU_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_GPU_2",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_GPU_3",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_IRoT_GPU_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_IRoT_GPU_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_IRoT_GPU_2",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_IRoT_GPU_3",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_ProcessorModule_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="HGX_ProcessorModule_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="IO_Board_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="IO_Board_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="IRoT_BF3_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="IRoT_CX8_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="IRoT_CX8_1",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="IRoT_CX8_2",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="IRoT_CX8_3",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="NVME_M2_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="PDB_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="Riser_Slot2_BlueField_3_Card",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="StorageBackplane_0",resource="chassis"} 1
redfish_chassis_health_rollup{chassis_id="StorageBackplane_1",resource="chassis"} 1
```


