### PR TITLE
adding in PCIe error metrics

### DIFF
--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -382,7 +382,7 @@ func parseProcessor(ch chan<- prometheus.Metric, systemHostName string, processo
 	// Fetch and emit ProcessorMetrics if available
 	processorMetrics, err := processor.Metrics()
 	if err != nil {
-		logger.Debug("error getting processor metrics", slog.String("processor", processorID), slog.Any("error", err))
+		logger.Error("error getting processor metrics", slog.String("processor", processorID), slog.Any("error", err))
 	} else if processorMetrics != nil {
 		// Emit PCIe error metrics
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_l0_to_recovery_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.L0ToRecoveryCount), systemProcessorLabelValues...)

--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -62,6 +62,16 @@ func createSystemMetricMap() map[string]Metric {
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_health_rollup", fmt.Sprintf("system processor health rollup,%s", CommonHealthHelp), SystemProcessorLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_total_threads", "system processor total threads", SystemProcessorLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_total_cores", "system processor total cores", SystemProcessorLabelNames)
+	
+	// PCIe error metrics for processors/GPUs
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_pcie_errors_l0_to_recovery_count", "system processor PCIe L0 to recovery state transition count", SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_pcie_errors_correctable_count", "system processor PCIe correctable error count", SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_pcie_errors_fatal_count", "system processor PCIe fatal error count", SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_pcie_errors_non_fatal_count", "system processor PCIe non-fatal error count", SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_pcie_errors_nak_received_count", "system processor PCIe NAK received count", SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_pcie_errors_nak_sent_count", "system processor PCIe NAK sent count", SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_pcie_errors_replay_count", "system processor PCIe replay count", SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_pcie_errors_replay_rollover_count", "system processor PCIe replay rollover count", SystemProcessorLabelNames)
 
 	addToMetricMap(systemMetrics, SystemSubsystem, "storage_volume_state", fmt.Sprintf("system storage volume state,%s", CommonStateHelp), SystemVolumeLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "storage_volume_health_state", fmt.Sprintf("system storage volume health state,%s", CommonHealthHelp), SystemVolumeLabelNames)
@@ -368,6 +378,19 @@ func parseProcessor(ch chan<- prometheus.Metric, systemHostName string, processo
 	}
 	ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_total_threads"].desc, prometheus.GaugeValue, float64(processorTotalThreads), systemProcessorLabelValues...)
 	ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_total_cores"].desc, prometheus.GaugeValue, float64(processorTotalCores), systemProcessorLabelValues...)
+	
+	// Fetch and emit ProcessorMetrics if available
+	if processorMetrics, err := processor.Metrics(); err == nil && processorMetrics != nil {
+		// Emit PCIe error metrics
+		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_l0_to_recovery_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.L0ToRecoveryCount), systemProcessorLabelValues...)
+		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_correctable_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.CorrectableErrorCount), systemProcessorLabelValues...)
+		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_fatal_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.FatalErrorCount), systemProcessorLabelValues...)
+		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_non_fatal_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.NonFatalErrorCount), systemProcessorLabelValues...)
+		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_nak_received_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.NAKReceivedCount), systemProcessorLabelValues...)
+		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_nak_sent_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.NAKSentCount), systemProcessorLabelValues...)
+		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_replay_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.ReplayCount), systemProcessorLabelValues...)
+		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_replay_rollover_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.ReplayRolloverCount), systemProcessorLabelValues...)
+	}
 }
 
 func parseVolume(ch chan<- prometheus.Metric, systemHostName string, volume *redfish.Volume, wg *sync.WaitGroup) {

--- a/collector/system_collector_test.go
+++ b/collector/system_collector_test.go
@@ -204,3 +204,69 @@ func TestDriveMetrics(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessorWithoutMetrics tests that processor collection works when ProcessorMetrics is not available
+func TestProcessorWithoutMetrics(t *testing.T) {
+	// Mock processor without metrics (no metrics field means Metrics() returns nil)
+	mockProcessor := &redfish.Processor{
+		Entity: common.Entity{
+			ID:   "CPU_1",
+			Name: "CPU 1",
+		},
+		TotalCores:   8,
+		TotalThreads: 16,
+		Status: common.Status{
+			State:        "Enabled",
+			Health:       "OK",
+			HealthRollup: "OK",
+		},
+	}
+
+	// Test metric collection
+	ch := make(chan prometheus.Metric, 100)
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+
+	go parseProcessor(ch, "test-host", mockProcessor, wg)
+	wg.Wait()
+
+	// Collect metrics from channel
+	processorMetricCount := 0
+	pcieErrorMetricCount := 0
+	basicMetrics := make(map[string]bool)
+
+	for len(ch) > 0 {
+		metric := <-ch
+		desc := metric.Desc().String()
+
+		if strings.Contains(desc, "processor") {
+			processorMetricCount++
+			if strings.Contains(desc, "pcie_errors") {
+				pcieErrorMetricCount++
+			}
+			// Track which basic metrics we got
+			if strings.Contains(desc, "processor_state") {
+				basicMetrics["state"] = true
+			} else if strings.Contains(desc, "processor_health_state") {
+				basicMetrics["health"] = true
+			} else if strings.Contains(desc, "processor_health_rollup") {
+				basicMetrics["health_rollup"] = true
+			} else if strings.Contains(desc, "processor_total_threads") {
+				basicMetrics["threads"] = true
+			} else if strings.Contains(desc, "processor_total_cores") {
+				basicMetrics["cores"] = true
+			}
+		}
+	}
+
+	// Verify basic metrics were collected
+	assert.Equal(t, 5, processorMetricCount, "Should have exactly 5 basic processor metrics")
+	assert.True(t, basicMetrics["state"], "Should have processor state metric")
+	assert.True(t, basicMetrics["health"], "Should have processor health metric")
+	assert.True(t, basicMetrics["health_rollup"], "Should have processor health rollup metric")
+	assert.True(t, basicMetrics["threads"], "Should have processor threads metric")
+	assert.True(t, basicMetrics["cores"], "Should have processor cores metric")
+
+	// Verify no PCIe error metrics were collected when ProcessorMetrics is unavailable
+	assert.Equal(t, 0, pcieErrorMetricCount, "Should have no PCIe error metrics when ProcessorMetrics is unavailable")
+}

--- a/collector/system_collector_test.go
+++ b/collector/system_collector_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -226,8 +227,11 @@ func TestProcessorWithoutMetrics(t *testing.T) {
 	ch := make(chan prometheus.Metric, 100)
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
+	
+	// Create a test logger
+	logger := slog.Default()
 
-	go parseProcessor(ch, "test-host", mockProcessor, wg)
+	go parseProcessor(ch, "test-host", mockProcessor, wg, logger)
 	wg.Wait()
 
 	// Collect metrics from channel


### PR DESCRIPTION
Summary
- Adds 8 PCIe error metrics from ProcessorMetrics for GB300 GPU monitoring

Changes
- Added PCIe error metric definitions to createSystemMetricMap()
- Added unit test for graceful handling when ProcessorMetrics unavailable

Testing
- Unit test added and passing
- Build successful

```
# HELP redfish_system_processor_pcie_errors_correctable_count system processor PCIe correctable error count
# TYPE redfish_system_processor_pcie_errors_correctable_count gauge
redfish_system_processor_pcie_errors_correctable_count{hostname="",processor="Processor",processor_id="CPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_correctable_count{hostname="",processor="Processor",processor_id="CPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_correctable_count{hostname="",processor="Processor",processor_id="GPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_correctable_count{hostname="",processor="Processor",processor_id="GPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_correctable_count{hostname="",processor="Processor",processor_id="GPU_2",resource="processor"} 0
redfish_system_processor_pcie_errors_correctable_count{hostname="",processor="Processor",processor_id="GPU_3",resource="processor"} 0
# HELP redfish_system_processor_pcie_errors_fatal_count system processor PCIe fatal error count
# TYPE redfish_system_processor_pcie_errors_fatal_count gauge
redfish_system_processor_pcie_errors_fatal_count{hostname="",processor="Processor",processor_id="CPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_fatal_count{hostname="",processor="Processor",processor_id="CPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_fatal_count{hostname="",processor="Processor",processor_id="GPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_fatal_count{hostname="",processor="Processor",processor_id="GPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_fatal_count{hostname="",processor="Processor",processor_id="GPU_2",resource="processor"} 0
redfish_system_processor_pcie_errors_fatal_count{hostname="",processor="Processor",processor_id="GPU_3",resource="processor"} 0
# HELP redfish_system_processor_pcie_errors_l0_to_recovery_count system processor PCIe L0 to recovery state transition count
# TYPE redfish_system_processor_pcie_errors_l0_to_recovery_count gauge
redfish_system_processor_pcie_errors_l0_to_recovery_count{hostname="",processor="Processor",processor_id="CPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_l0_to_recovery_count{hostname="",processor="Processor",processor_id="CPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_l0_to_recovery_count{hostname="",processor="Processor",processor_id="GPU_0",resource="processor"} 4
redfish_system_processor_pcie_errors_l0_to_recovery_count{hostname="",processor="Processor",processor_id="GPU_1",resource="processor"} 4
redfish_system_processor_pcie_errors_l0_to_recovery_count{hostname="",processor="Processor",processor_id="GPU_2",resource="processor"} 4
redfish_system_processor_pcie_errors_l0_to_recovery_count{hostname="",processor="Processor",processor_id="GPU_3",resource="processor"} 4
# HELP redfish_system_processor_pcie_errors_nak_received_count system processor PCIe NAK received count
# TYPE redfish_system_processor_pcie_errors_nak_received_count gauge
redfish_system_processor_pcie_errors_nak_received_count{hostname="",processor="Processor",processor_id="CPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_nak_received_count{hostname="",processor="Processor",processor_id="CPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_nak_received_count{hostname="",processor="Processor",processor_id="GPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_nak_received_count{hostname="",processor="Processor",processor_id="GPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_nak_received_count{hostname="",processor="Processor",processor_id="GPU_2",resource="processor"} 0
redfish_system_processor_pcie_errors_nak_received_count{hostname="",processor="Processor",processor_id="GPU_3",resource="processor"} 0
# HELP redfish_system_processor_pcie_errors_nak_sent_count system processor PCIe NAK sent count
# TYPE redfish_system_processor_pcie_errors_nak_sent_count gauge
redfish_system_processor_pcie_errors_nak_sent_count{hostname="",processor="Processor",processor_id="CPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_nak_sent_count{hostname="",processor="Processor",processor_id="CPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_nak_sent_count{hostname="",processor="Processor",processor_id="GPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_nak_sent_count{hostname="",processor="Processor",processor_id="GPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_nak_sent_count{hostname="",processor="Processor",processor_id="GPU_2",resource="processor"} 0
redfish_system_processor_pcie_errors_nak_sent_count{hostname="",processor="Processor",processor_id="GPU_3",resource="processor"} 0
# HELP redfish_system_processor_pcie_errors_non_fatal_count system processor PCIe non-fatal error count
# TYPE redfish_system_processor_pcie_errors_non_fatal_count gauge
redfish_system_processor_pcie_errors_non_fatal_count{hostname="",processor="Processor",processor_id="CPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_non_fatal_count{hostname="",processor="Processor",processor_id="CPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_non_fatal_count{hostname="",processor="Processor",processor_id="GPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_non_fatal_count{hostname="",processor="Processor",processor_id="GPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_non_fatal_count{hostname="",processor="Processor",processor_id="GPU_2",resource="processor"} 0
redfish_system_processor_pcie_errors_non_fatal_count{hostname="",processor="Processor",processor_id="GPU_3",resource="processor"} 0
# HELP redfish_system_processor_pcie_errors_replay_count system processor PCIe replay count
# TYPE redfish_system_processor_pcie_errors_replay_count gauge
redfish_system_processor_pcie_errors_replay_count{hostname="",processor="Processor",processor_id="CPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_replay_count{hostname="",processor="Processor",processor_id="CPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_replay_count{hostname="",processor="Processor",processor_id="GPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_replay_count{hostname="",processor="Processor",processor_id="GPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_replay_count{hostname="",processor="Processor",processor_id="GPU_2",resource="processor"} 0
redfish_system_processor_pcie_errors_replay_count{hostname="",processor="Processor",processor_id="GPU_3",resource="processor"} 0
# HELP redfish_system_processor_pcie_errors_replay_rollover_count system processor PCIe replay rollover count
# TYPE redfish_system_processor_pcie_errors_replay_rollover_count gauge
redfish_system_processor_pcie_errors_replay_rollover_count{hostname="",processor="Processor",processor_id="CPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_replay_rollover_count{hostname="",processor="Processor",processor_id="CPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_replay_rollover_count{hostname="",processor="Processor",processor_id="GPU_0",resource="processor"} 0
redfish_system_processor_pcie_errors_replay_rollover_count{hostname="",processor="Processor",processor_id="GPU_1",resource="processor"} 0
redfish_system_processor_pcie_errors_replay_rollover_count{hostname="",processor="Processor",processor_id="GPU_2",resource="processor"} 0
redfish_system_processor_pcie_errors_replay_rollover_count{hostname="",processor="Processor",processor_id="GPU_3",resource="processor"} 0
```