### PR TITLE
add metrics for correctable and uncorrectable cache errors

### DIFF
--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -72,6 +72,10 @@ func createSystemMetricMap() map[string]Metric {
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_pcie_errors_nak_sent_count", "system processor PCIe NAK sent count", SystemProcessorLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_pcie_errors_replay_count", "system processor PCIe replay count", SystemProcessorLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_pcie_errors_replay_rollover_count", "system processor PCIe replay rollover count", SystemProcessorLabelNames)
+	
+	// Cache metrics for processors/GPUs
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_cache_lifetime_uncorrectable_ecc_error_count", "system processor cache lifetime uncorrectable ECC error count", SystemProcessorLabelNames)
+	addToMetricMap(systemMetrics, SystemSubsystem, "processor_cache_lifetime_correctable_ecc_error_count", "system processor cache lifetime correctable ECC error count", SystemProcessorLabelNames)
 
 	addToMetricMap(systemMetrics, SystemSubsystem, "storage_volume_state", fmt.Sprintf("system storage volume state,%s", CommonStateHelp), SystemVolumeLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "storage_volume_health_state", fmt.Sprintf("system storage volume health state,%s", CommonHealthHelp), SystemVolumeLabelNames)
@@ -393,6 +397,10 @@ func parseProcessor(ch chan<- prometheus.Metric, systemHostName string, processo
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_nak_sent_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.NAKSentCount), systemProcessorLabelValues...)
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_replay_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.ReplayCount), systemProcessorLabelValues...)
 		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_pcie_errors_replay_rollover_count"].desc, prometheus.GaugeValue, float64(processorMetrics.PCIeErrors.ReplayRolloverCount), systemProcessorLabelValues...)
+		
+		// Emit cache metrics
+		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_cache_lifetime_uncorrectable_ecc_error_count"].desc, prometheus.GaugeValue, float64(processorMetrics.CacheMetricsTotal.LifeTime.UncorrectableECCErrorCount), systemProcessorLabelValues...)
+		ch <- prometheus.MustNewConstMetric(systemMetrics["system_processor_cache_lifetime_correctable_ecc_error_count"].desc, prometheus.GaugeValue, float64(processorMetrics.CacheMetricsTotal.LifeTime.CorrectableECCErrorCount), systemProcessorLabelValues...)
 	}
 }
 

--- a/collector/system_collector_test.go
+++ b/collector/system_collector_test.go
@@ -237,6 +237,7 @@ func TestProcessorWithoutMetrics(t *testing.T) {
 	// Collect metrics from channel
 	processorMetricCount := 0
 	pcieErrorMetricCount := 0
+	cacheMetricCount := 0
 	basicMetrics := make(map[string]bool)
 
 	for len(ch) > 0 {
@@ -247,6 +248,8 @@ func TestProcessorWithoutMetrics(t *testing.T) {
 			processorMetricCount++
 			if strings.Contains(desc, "pcie_errors") {
 				pcieErrorMetricCount++
+			} else if strings.Contains(desc, "cache_lifetime") {
+				cacheMetricCount++
 			}
 			// Track which basic metrics we got
 			if strings.Contains(desc, "processor_state") {
@@ -273,4 +276,7 @@ func TestProcessorWithoutMetrics(t *testing.T) {
 
 	// Verify no PCIe error metrics were collected when ProcessorMetrics is unavailable
 	assert.Equal(t, 0, pcieErrorMetricCount, "Should have no PCIe error metrics when ProcessorMetrics is unavailable")
+	
+	// Verify no cache metrics were collected when ProcessorMetrics is unavailable
+	assert.Equal(t, 0, cacheMetricCount, "Should have no cache metrics when ProcessorMetrics is unavailable")
 }


### PR DESCRIPTION
Summary
- Adds 2 new processor metrics from ProcessorMetrics for GB300 GPU monitoring
- Metrics: CacheMetricsTotal.LifeTime.CorrectableECCErrorCount and UncorrectableECCErrorCount

Changes
- Added cache metric definitions in createSystemMetricMap()
- Updated parseProcessor() to emit cache ECC error counts from ProcessorMetrics
- Updated unit test to verify no cache metrics emitted when ProcessorMetrics unavailable

Testing
- Unit test added and passing
- Build successful

```
# HELP redfish_system_processor_cache_lifetime_correctable_ecc_error_count system processor cache lifetime correctable ECC error count
# TYPE redfish_system_processor_cache_lifetime_correctable_ecc_error_count gauge
redfish_system_processor_cache_lifetime_correctable_ecc_error_count{hostname="",processor="Processor",processor_id="CPU_0",resource="processor"} 0
redfish_system_processor_cache_lifetime_correctable_ecc_error_count{hostname="",processor="Processor",processor_id="CPU_1",resource="processor"} 0
redfish_system_processor_cache_lifetime_correctable_ecc_error_count{hostname="",processor="Processor",processor_id="GPU_0",resource="processor"} 0
redfish_system_processor_cache_lifetime_correctable_ecc_error_count{hostname="",processor="Processor",processor_id="GPU_1",resource="processor"} 0
redfish_system_processor_cache_lifetime_correctable_ecc_error_count{hostname="",processor="Processor",processor_id="GPU_2",resource="processor"} 0
redfish_system_processor_cache_lifetime_correctable_ecc_error_count{hostname="",processor="Processor",processor_id="GPU_3",resource="processor"} 0
# HELP redfish_system_processor_cache_lifetime_uncorrectable_ecc_error_count system processor cache lifetime uncorrectable ECC error count
# TYPE redfish_system_processor_cache_lifetime_uncorrectable_ecc_error_count gauge
redfish_system_processor_cache_lifetime_uncorrectable_ecc_error_count{hostname="",processor="Processor",processor_id="CPU_0",resource="processor"} 0
redfish_system_processor_cache_lifetime_uncorrectable_ecc_error_count{hostname="",processor="Processor",processor_id="CPU_1",resource="processor"} 0
redfish_system_processor_cache_lifetime_uncorrectable_ecc_error_count{hostname="",processor="Processor",processor_id="GPU_0",resource="processor"} 0
redfish_system_processor_cache_lifetime_uncorrectable_ecc_error_count{hostname="",processor="Processor",processor_id="GPU_1",resource="processor"} 0
redfish_system_processor_cache_lifetime_uncorrectable_ecc_error_count{hostname="",processor="Processor",processor_id="GPU_2",resource="processor"} 0
redfish_system_processor_cache_lifetime_uncorrectable_ecc_error_count{hostname="",processor="Processor",processor_id="GPU_3",resource="processor"} 0
```