### PR TITLE
Add GPU ECC Metrics

### DIFF
--- a/collector/gpu_collector.go
+++ b/collector/gpu_collector.go
@@ -10,10 +10,17 @@ import (
 )
 
 var (
-	gpuSubsystem  = "gpu"
-	gpuBaseLabels = []string{"resource", "system", "id"}
-	gpuMetrics    = createGPUMetricMap()
+	gpuSubsystem    = "gpu"
+	gpuBaseLabels   = []string{"resource", "system", "gpu_id"}
+	gpuMemoryLabels = baseWithExtraLabels([]string{"memory_id"})
+	gpuMetrics      = createGPUMetricMap()
 )
+
+func baseWithExtraLabels(extra []string) []string {
+	gpuBaseLabelsCopy := make([]string, len(gpuBaseLabels))
+	copy(gpuBaseLabelsCopy, gpuBaseLabels)
+	return append(gpuBaseLabelsCopy, extra...)
+}
 
 type GPUCollector struct {
 	rfClient              *gofish.APIClient
@@ -25,6 +32,8 @@ type GPUCollector struct {
 func createGPUMetricMap() map[string]Metric {
 	gpuMetrics := make(map[string]Metric)
 	addToMetricMap(gpuMetrics, gpuSubsystem, "health", "health of gpu reported by system,1(OK),2(Warning),3(Critical)", gpuBaseLabels)
+	addToMetricMap(gpuMetrics, gpuSubsystem, "memory_ecc_correctable", "current correctable memory ecc errors reported on the gpu", gpuMemoryLabels)
+	addToMetricMap(gpuMetrics, gpuSubsystem, "memory_ecc_uncorrectable", "current uncorrectable memory ecc errors reported on the gpu", gpuMemoryLabels)
 	return gpuMetrics
 }
 
@@ -93,7 +102,51 @@ func collectSystemGPUMetrics(ch chan<- prometheus.Metric, system *redfish.Comput
 		}
 		commonGPULabels := []string{gpu.Name, system.Name, gpu.ID}
 		emitGPUHealth(ch, gpu, commonGPULabels)
-		// emitGPUECCMetrics(ch, systemName, gpu)
+		gpuMem, err := gpu.Memory()
+		if err != nil {
+			logger.Error("error getting gpu memory", slog.Any("error", err))
+			continue
+		}
+		memWithMetrics := make([]MemoryWithMetrics, len(gpuMem))
+		for i, mem := range gpuMem {
+			memWithMetrics[i] = &redfishMemoryAdapter{Memory: mem}
+		}
+		emitGPUECCMetrics(ch, memWithMetrics, logger, commonGPULabels)
+	}
+}
+
+type MemoryWithMetrics interface {
+	Metrics() (*redfish.MemoryMetrics, error)
+	GetID() string
+}
+
+type redfishMemoryAdapter struct {
+	*redfish.Memory
+}
+
+func (r *redfishMemoryAdapter) GetID() string {
+	return r.ID
+}
+
+func emitGPUECCMetrics(ch chan<- prometheus.Metric, mem []MemoryWithMetrics, logger *slog.Logger, commonLabels []string) {
+	for _, m := range mem {
+		memMetric, err := m.Metrics()
+		if err != nil {
+			logger.Error("error getting gpu memory metrics", slog.Any("error", err))
+			continue
+		}
+		metricLabels := append(commonLabels, m.GetID())
+
+		ch <- prometheus.MustNewConstMetric(
+			gpuMetrics["gpu_memory_ecc_correctable"].desc,
+			prometheus.CounterValue,
+			float64(memMetric.CurrentPeriod.CorrectableECCErrorCount),
+			metricLabels...)
+		ch <- prometheus.MustNewConstMetric(
+			gpuMetrics["gpu_memory_ecc_uncorrectable"].desc,
+			prometheus.CounterValue,
+			float64(memMetric.CurrentPeriod.UncorrectableECCErrorCount),
+			metricLabels...)
 	}
 }
 

--- a/collector/gpu_collector_test.go
+++ b/collector/gpu_collector_test.go
@@ -1,6 +1,9 @@
 package collector
 
 import (
+	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -85,8 +88,102 @@ func TestCollectSystemGPUMetrics(t *testing.T) {
 	}
 }
 
+// mockMemoryWithMetrics implements MemoryWithMetrics interface for testing
+type mockMemoryWithMetrics struct {
+	id                         string
+	correctableECCErrorCount   int
+	uncorrectableECCErrorCount int
+	shouldError                bool
+}
+
+func (m *mockMemoryWithMetrics) GetID() string {
+	return m.id
+}
+
+func (m *mockMemoryWithMetrics) Metrics() (*redfish.MemoryMetrics, error) {
+	if m.shouldError {
+		return nil, errors.New("metrics retrieval failed")
+	}
+
+	return &redfish.MemoryMetrics{
+		CurrentPeriod: redfish.CurrentPeriod{
+			CorrectableECCErrorCount:   m.correctableECCErrorCount,
+			UncorrectableECCErrorCount: m.uncorrectableECCErrorCount,
+		},
+	}, nil
+}
+
 func TestEmitGPUECCMetrics(t *testing.T) {
-	t.Fail()
+	tT := map[string]struct {
+		memories             []MemoryWithMetrics
+		systemName           string
+		expectedMetricCount  int
+		expectedMetricChecks []struct {
+			nameContains  string
+			expectedValue float64
+		}
+	}{
+		"happy path": {
+			memories: []MemoryWithMetrics{
+				&mockMemoryWithMetrics{
+					id:                         "mockMem",
+					correctableECCErrorCount:   100,
+					uncorrectableECCErrorCount: 0,
+				},
+			},
+			systemName:          "test",
+			expectedMetricCount: 2,
+			expectedMetricChecks: []struct {
+				nameContains  string
+				expectedValue float64
+			}{
+				{nameContains: "memory_ecc_correctable", expectedValue: 100},
+				{nameContains: "memory_ecc_uncorrectable", expectedValue: 0},
+			},
+		},
+		// should simply error from within functon-under-test, no returned metrics
+		"no memory metrics": {
+			memories: []MemoryWithMetrics{
+				&mockMemoryWithMetrics{
+					id:          "mockMem",
+					shouldError: true,
+				},
+			},
+			systemName:          "test",
+			expectedMetricCount: 0,
+		},
+	}
+
+	for tName, test := range tT {
+		t.Run(tName, func(t *testing.T) {
+			outCh := make(chan prometheus.Metric, 100)
+			go func() {
+				emitGPUECCMetrics(outCh, test.memories, slog.Default(), []string{"testGPU", test.systemName, "testGPUId"})
+				close(outCh)
+			}()
+
+			var metrics []prometheus.Metric
+			for metric := range outCh {
+				metrics = append(metrics, metric)
+			}
+
+			require.Equal(t, test.expectedMetricCount, len(metrics), "unexpected number of metrics")
+
+			for _, check := range test.expectedMetricChecks {
+				found := false
+				for _, metric := range metrics {
+					if descContains(metric, check.nameContains) {
+						found = true
+						dtoMetric := &dto.Metric{}
+						require.NoError(t, metric.Write(dtoMetric), "unexpected error writing DTO metric")
+						requireCounterWithValue(t, dtoMetric, check.expectedValue)
+						break
+					}
+				}
+				assert.True(t, found, "expected metric containing '%s' not found", check.nameContains)
+			}
+		})
+	}
 }
 
 func requireGaugeWithValue(t *testing.T, metric *dto.Metric, expected float64) {
@@ -95,9 +192,23 @@ func requireGaugeWithValue(t *testing.T, metric *dto.Metric, expected float64) {
 	require.Equal(t, expected, *metric.Gauge.Value)
 }
 
+func requireCounterWithValue(t *testing.T, metric *dto.Metric, expected float64) {
+	t.Helper()
+	require.NotNil(t, metric.Counter, "required a counter")
+	require.Equal(t, expected, *metric.Counter.Value)
+}
+
 func requireMetricDescContains(t *testing.T, m prometheus.Metric, contains string) {
 	t.Helper()
 	desc := m.Desc()
 	assert.NotNil(t, desc)
 	require.Contains(t, desc.String(), contains)
+}
+
+func descContains(m prometheus.Metric, contains string) bool {
+	desc := m.Desc()
+	if desc == nil {
+		return false
+	}
+	return strings.Contains(desc.String(), contains)
 }


### PR DESCRIPTION
Refactors gpu labels slightly, and adds an interface for GPUs primarily to support mocks.

Then, adds functionality to extract GPU memory ECC counts for correctable/uncorrectable errors.

I'm proposing these as counters, and from my understanding the values extracted from Redfish should also follow Prometheus counter semantics (the only possibilities being either _the value goes up_, or _an operator has explicitly reset the counter to a 0 value using a RF API_)

Tested via unit tests, pointing a compiled binary against prefetched GB300 host data, and then against a GH200 "in the wild" it correctly skipped looking up data as no memory objects were to be found.