### PR TITLE
adding nvidia oem metrics

### DIFF
--- a/collector/gpu_collector.go
+++ b/collector/gpu_collector.go
@@ -16,9 +16,9 @@ const GPUSubsystem = "gpu"
 
 // GPU metric label names
 var (
-	GPUMemoryLabelNames    = []string{"hostname", "system_id", "gpu_id", "memory_id"}
-	GPUProcessorLabelNames = []string{"hostname", "system_id", "gpu_id", "processor_name"}
-	GPUPortLabelNames      = []string{"hostname", "system_id", "gpu_id", "port_id", "port_type"}
+	gpuMemoryLabelNames    = []string{"hostname", "system_id", "gpu_id", "memory_id"}
+	gpuProcessorLabelNames = []string{"hostname", "system_id", "gpu_id", "processor_name"}
+	gpuPortLabelNames      = []string{"hostname", "system_id", "gpu_id", "port_id", "port_type"}
 	gpuMetrics             = createGPUMetricMap()
 )
 
@@ -35,48 +35,48 @@ func createGPUMetricMap() map[string]Metric {
 	gpuMetrics := make(map[string]Metric)
 
 	// GPU Memory metrics
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_capacity_mib", "GPU memory capacity in MiB", GPUMemoryLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_state", fmt.Sprintf("GPU memory state,%s", CommonStateHelp), GPUMemoryLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_health", fmt.Sprintf("GPU memory health,%s", CommonHealthHelp), GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_capacity_mib", "GPU memory capacity in MiB", gpuMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_state", fmt.Sprintf("GPU memory state,%s", CommonStateHelp), gpuMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_health", fmt.Sprintf("GPU memory health,%s", CommonHealthHelp), gpuMemoryLabelNames)
 
 	// Nvidia GPU Memory OEM metrics
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_row_remapping_failed", "GPU memory row remapping failed status (1 if failed)", GPUMemoryLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_row_remapping_pending", "GPU memory row remapping pending status (1 if pending)", GPUMemoryLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_correctable_row_remapping_count", "GPU memory correctable row remapping count", GPUMemoryLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_uncorrectable_row_remapping_count", "GPU memory uncorrectable row remapping count", GPUMemoryLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_high_availability_bank_count", "GPU memory high availability bank count", GPUMemoryLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_low_availability_bank_count", "GPU memory low availability bank count", GPUMemoryLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_no_availability_bank_count", "GPU memory no availability bank count", GPUMemoryLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_partial_availability_bank_count", "GPU memory partial availability bank count", GPUMemoryLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_max_availability_bank_count", "GPU memory max availability bank count", GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_row_remapping_failed", "GPU memory row remapping failed status (1 if failed)", gpuMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_row_remapping_pending", "GPU memory row remapping pending status (1 if pending)", gpuMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_correctable_row_remapping_count", "GPU memory correctable row remapping count", gpuMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_uncorrectable_row_remapping_count", "GPU memory uncorrectable row remapping count", gpuMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_high_availability_bank_count", "GPU memory high availability bank count", gpuMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_low_availability_bank_count", "GPU memory low availability bank count", gpuMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_no_availability_bank_count", "GPU memory no availability bank count", gpuMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_partial_availability_bank_count", "GPU memory partial availability bank count", gpuMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_max_availability_bank_count", "GPU memory max availability bank count", gpuMemoryLabelNames)
 
 	// GPU Processor metrics
-	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_state", fmt.Sprintf("GPU processor state,%s", CommonStateHelp), GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_health", fmt.Sprintf("GPU processor health,%s", CommonHealthHelp), GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_total_cores", "GPU processor total cores", GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_total_threads", "GPU processor total threads", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_state", fmt.Sprintf("GPU processor state,%s", CommonStateHelp), gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_health", fmt.Sprintf("GPU processor health,%s", CommonHealthHelp), gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_total_cores", "GPU processor total cores", gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_total_threads", "GPU processor total threads", gpuProcessorLabelNames)
 
 	// Nvidia GPU Processor OEM metrics
-	addToMetricMap(gpuMetrics, GPUSubsystem, "sm_utilization_percent", "GPU SM utilization percentage", GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "sm_activity_percent", "GPU SM activity percentage", GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "sm_occupancy_percent", "GPU SM occupancy percentage", GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "tensor_core_activity_percent", "GPU tensor core activity percentage", GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "fp16_activity_percent", "GPU FP16 activity percentage", GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "fp32_activity_percent", "GPU FP32 activity percentage", GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "fp64_activity_percent", "GPU FP64 activity percentage", GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "sram_ecc_error_threshold_exceeded", "GPU SRAM ECC error threshold exceeded (1 if exceeded)", GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "pcie_rx_bytes", "GPU PCIe receive bytes", GPUProcessorLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "pcie_tx_bytes", "GPU PCIe transmit bytes", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "sm_utilization_percent", "GPU SM utilization percentage", gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "sm_activity_percent", "GPU SM activity percentage", gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "sm_occupancy_percent", "GPU SM occupancy percentage", gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "tensor_core_activity_percent", "GPU tensor core activity percentage", gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "fp16_activity_percent", "GPU FP16 activity percentage", gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "fp32_activity_percent", "GPU FP32 activity percentage", gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "fp64_activity_percent", "GPU FP64 activity percentage", gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "sram_ecc_error_threshold_exceeded", "GPU SRAM ECC error threshold exceeded (1 if exceeded)", gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "pcie_rx_bytes", "GPU PCIe receive bytes", gpuProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "pcie_tx_bytes", "GPU PCIe transmit bytes", gpuProcessorLabelNames)
 
 	// NVLink Port metrics
-	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_state", fmt.Sprintf("NVLink port state,%s", CommonStateHelp), GPUPortLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_health", fmt.Sprintf("NVLink port health,%s", CommonHealthHelp), GPUPortLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_runtime_error", "NVLink runtime error status (1 if error)", GPUPortLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_training_error", "NVLink training error status (1 if error)", GPUPortLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_link_error_recovery_count", "NVLink error recovery count", GPUPortLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_link_downed_count", "NVLink link downed count", GPUPortLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_symbol_errors", "NVLink symbol error count", GPUPortLabelNames)
-	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_bit_error_rate", "NVLink bit error rate", GPUPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_state", fmt.Sprintf("NVLink port state,%s", CommonStateHelp), gpuPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_health", fmt.Sprintf("NVLink port health,%s", CommonHealthHelp), gpuPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_runtime_error", "NVLink runtime error status (1 if error)", gpuPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_training_error", "NVLink training error status (1 if error)", gpuPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_link_error_recovery_count", "NVLink error recovery count", gpuPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_link_downed_count", "NVLink link downed count", gpuPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_symbol_errors", "NVLink symbol error count", gpuPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_bit_error_rate", "NVLink bit error rate", gpuPortLabelNames)
 
 	return gpuMetrics
 }

--- a/collector/gpu_collector.go
+++ b/collector/gpu_collector.go
@@ -475,13 +475,13 @@ func (g *GPUCollector) collectNVLinkPorts(ch chan<- prometheus.Metric, systemNam
 				ch <- prometheus.MustNewConstMetric(
 					g.metrics["gpu_nvlink_runtime_error"].desc,
 					prometheus.GaugeValue,
-					boolToFloat64(metricsOEM.NVLinkErrorsRuntimeError),
+					boolToFloat64(metricsOEM.NVLinkErrors.RuntimeError),
 					labels...,
 				)
 				ch <- prometheus.MustNewConstMetric(
 					g.metrics["gpu_nvlink_training_error"].desc,
 					prometheus.GaugeValue,
-					boolToFloat64(metricsOEM.NVLinkErrorsTrainingError),
+					boolToFloat64(metricsOEM.NVLinkErrors.TrainingError),
 					labels...,
 				)
 				ch <- prometheus.MustNewConstMetric(

--- a/collector/gpu_collector.go
+++ b/collector/gpu_collector.go
@@ -144,7 +144,7 @@ func (g *GPUCollector) collectSystemGPUs(ch chan<- prometheus.Metric, system *re
 	// Collect GPU memory metrics
 	wgMemory := &sync.WaitGroup{}
 	if memories, err := system.Memory(); err != nil {
-		g.logger.Debug("failed to get memory for system",
+		g.logger.Error("failed to get memory for system",
 			slog.String("system_id", systemID),
 			slog.Any("error", err),
 		)

--- a/collector/gpu_collector.go
+++ b/collector/gpu_collector.go
@@ -18,7 +18,7 @@ const GPUSubsystem = "gpu"
 var (
 	gpuMemoryLabelNames    = []string{"hostname", "system_id", "gpu_id", "memory_id"}
 	gpuProcessorLabelNames = []string{"hostname", "system_id", "gpu_id", "processor_name"}
-	gpuPortLabelNames      = []string{"hostname", "system_id", "gpu_id", "port_id", "port_type"}
+	gpuPortLabelNames      = []string{"hostname", "system_id", "gpu_id", "port_id", "port_type", "port_protocol"}
 	gpuMetrics             = createGPUMetricMap()
 	gpuMemoryTypes         = createGPUMemoryTypeSet()
 )
@@ -447,11 +447,8 @@ func (g *GPUCollector) collectNVLinkPorts(ch chan<- prometheus.Metric, systemNam
 
 		portID := port.ID
 		portType := string(port.PortType)
-		// Use PortProtocol name if PortType is empty
-		if portType == "" {
-			portType = string(port.PortProtocol)
-		}
-		labels := []string{systemName, systemID, gpuID, portID, portType}
+		portProtocol := string(port.PortProtocol)
+		labels := []string{systemName, systemID, gpuID, portID, portType, portProtocol}
 
 		// Basic port metrics
 		if stateValue, ok := parseCommonStatusState(port.Status.State); ok {

--- a/collector/gpu_collector.go
+++ b/collector/gpu_collector.go
@@ -1,7 +1,9 @@
 package collector
 
 import (
+	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -9,30 +11,82 @@ import (
 	"github.com/stmcginnis/gofish/redfish"
 )
 
+// GPUSubsystem is the GPU subsystem name
+const GPUSubsystem = "gpu"
+
+// GPU metric label names
 var (
-	gpuSubsystem  = "gpu"
-	gpuBaseLabels = []string{"resource", "system", "id"}
-	gpuMetrics    = createGPUMetricMap()
+	GPUMemoryLabelNames    = []string{"hostname", "system_id", "gpu_id", "memory_id"}
+	GPUProcessorLabelNames = []string{"hostname", "system_id", "gpu_id", "processor_name"}
+	GPUPortLabelNames      = []string{"hostname", "system_id", "gpu_id", "port_id", "port_type"}
+	gpuMetrics             = createGPUMetricMap()
 )
 
+// GPUCollector collects GPU-specific metrics including Nvidia OEM fields
 type GPUCollector struct {
-	rfClient              *gofish.APIClient
+	redfishClient         *gofish.APIClient
 	metrics               map[string]Metric
 	logger                *slog.Logger
 	collectorScrapeStatus *prometheus.GaugeVec
+	oemHelper             *NvidiaOEMHelper
 }
 
 func createGPUMetricMap() map[string]Metric {
 	gpuMetrics := make(map[string]Metric)
-	addToMetricMap(gpuMetrics, gpuSubsystem, "health", "health of gpu reported by system,1(OK),2(Warning),3(Critical)", gpuBaseLabels)
+
+	// GPU Memory metrics
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_capacity_mib", "GPU memory capacity in MiB", GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_state", fmt.Sprintf("GPU memory state,%s", CommonStateHelp), GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_health", fmt.Sprintf("GPU memory health,%s", CommonHealthHelp), GPUMemoryLabelNames)
+
+	// Nvidia GPU Memory OEM metrics
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_row_remapping_failed", "GPU memory row remapping failed status (1 if failed)", GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_row_remapping_pending", "GPU memory row remapping pending status (1 if pending)", GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_correctable_row_remapping_count", "GPU memory correctable row remapping count", GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_uncorrectable_row_remapping_count", "GPU memory uncorrectable row remapping count", GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_high_availability_bank_count", "GPU memory high availability bank count", GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_low_availability_bank_count", "GPU memory low availability bank count", GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_no_availability_bank_count", "GPU memory no availability bank count", GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_partial_availability_bank_count", "GPU memory partial availability bank count", GPUMemoryLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_max_availability_bank_count", "GPU memory max availability bank count", GPUMemoryLabelNames)
+
+	// GPU Processor metrics
+	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_state", fmt.Sprintf("GPU processor state,%s", CommonStateHelp), GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_health", fmt.Sprintf("GPU processor health,%s", CommonHealthHelp), GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_total_cores", "GPU processor total cores", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "processor_total_threads", "GPU processor total threads", GPUProcessorLabelNames)
+
+	// Nvidia GPU Processor OEM metrics
+	addToMetricMap(gpuMetrics, GPUSubsystem, "sm_utilization_percent", "GPU SM utilization percentage", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "sm_activity_percent", "GPU SM activity percentage", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "sm_occupancy_percent", "GPU SM occupancy percentage", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "tensor_core_activity_percent", "GPU tensor core activity percentage", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "fp16_activity_percent", "GPU FP16 activity percentage", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "fp32_activity_percent", "GPU FP32 activity percentage", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "fp64_activity_percent", "GPU FP64 activity percentage", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "sram_ecc_error_threshold_exceeded", "GPU SRAM ECC error threshold exceeded (1 if exceeded)", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "pcie_rx_bytes", "GPU PCIe receive bytes", GPUProcessorLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "pcie_tx_bytes", "GPU PCIe transmit bytes", GPUProcessorLabelNames)
+
+	// NVLink Port metrics
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_state", fmt.Sprintf("NVLink port state,%s", CommonStateHelp), GPUPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_health", fmt.Sprintf("NVLink port health,%s", CommonHealthHelp), GPUPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_runtime_error", "NVLink runtime error status (1 if error)", GPUPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_training_error", "NVLink training error status (1 if error)", GPUPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_link_error_recovery_count", "NVLink error recovery count", GPUPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_link_downed_count", "NVLink link downed count", GPUPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_symbol_errors", "NVLink symbol error count", GPUPortLabelNames)
+	addToMetricMap(gpuMetrics, GPUSubsystem, "nvlink_bit_error_rate", "NVLink bit error rate", GPUPortLabelNames)
+
 	return gpuMetrics
 }
 
-func NewGPUCollector(rfClient *gofish.APIClient, logger *slog.Logger) *GPUCollector {
+// NewGPUCollector creates a new GPU collector
+func NewGPUCollector(redfishClient *gofish.APIClient, logger *slog.Logger) *GPUCollector {
 	return &GPUCollector{
-		rfClient: rfClient,
-		metrics:  gpuMetrics,
-		logger:   logger.With(slog.String("collector", "GPUCollector")),
+		redfishClient: redfishClient,
+		metrics:       gpuMetrics,
+		logger:        logger.With(slog.String("collector", "GPUCollector")),
 		collectorScrapeStatus: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
@@ -41,9 +95,11 @@ func NewGPUCollector(rfClient *gofish.APIClient, logger *slog.Logger) *GPUCollec
 			},
 			[]string{"collector"},
 		),
+		oemHelper: NewNvidiaOEMHelper(redfishClient.GetService().GetClient(), logger),
 	}
 }
 
+// Describe implements prometheus.Collector
 func (g *GPUCollector) Describe(ch chan<- *prometheus.Desc) {
 	for _, metric := range g.metrics {
 		ch <- metric.desc
@@ -51,74 +107,401 @@ func (g *GPUCollector) Describe(ch chan<- *prometheus.Desc) {
 	g.collectorScrapeStatus.Describe(ch)
 }
 
+// Collect implements prometheus.Collector
 func (g *GPUCollector) Collect(ch chan<- prometheus.Metric) {
-	service := g.rfClient.Service
+	g.collectorScrapeStatus.WithLabelValues("gpu").Set(float64(0))
+
+	service := g.redfishClient.Service
 	systems, err := service.Systems()
 	if err != nil {
 		g.logger.Error("failed getting systems",
-			slog.Any("error", err.Error()),
+			slog.Any("error", err),
 			slog.String("operation", "service.Systems()"),
 		)
-		g.collectorScrapeStatus.WithLabelValues("gpu").Set(float64(0))
 		return
 	}
+
 	wg := &sync.WaitGroup{}
 	for _, system := range systems {
 		wg.Add(1)
-		// Gather GPU metrics per-discovered-system
-		go collectSystemGPUMetrics(ch, system, wg, g.logger)
+		go g.collectSystemGPUs(ch, system, wg)
 	}
 	wg.Wait()
+
 	g.collectorScrapeStatus.WithLabelValues("gpu").Set(float64(1))
 }
 
-func collectSystemGPUMetrics(ch chan<- prometheus.Metric, system *redfish.ComputerSystem, wg *sync.WaitGroup, logger *slog.Logger) {
+// collectSystemGPUs collects all GPU-related metrics for a system
+func (g *GPUCollector) collectSystemGPUs(ch chan<- prometheus.Metric, system *redfish.ComputerSystem, wg *sync.WaitGroup) {
 	defer wg.Done()
-	cpus, err := system.Processors()
+
+	systemID := system.ID
+	systemName := system.Name
+	if systemName == "" {
+		systemName = systemID
+	}
+
+	// Collect GPU memory metrics
+	wgMemory := &sync.WaitGroup{}
+	if memories, err := system.Memory(); err != nil {
+		g.logger.Debug("failed to get memory for system",
+			slog.String("system_id", systemID),
+			slog.Any("error", err),
+		)
+	} else {
+		for _, memory := range memories {
+			if IsNvidiaGPUMemory(memory.ID) {
+				wgMemory.Add(1)
+				go g.collectGPUMemory(ch, systemName, systemID, memory, wgMemory)
+			}
+		}
+	}
+
+	// Collect GPU processor metrics
+	wgProcessor := &sync.WaitGroup{}
+	if processors, err := system.Processors(); err != nil {
+		g.logger.Debug("failed to get processors for system",
+			slog.String("system_id", systemID),
+			slog.Any("error", err),
+		)
+	} else {
+		for _, processor := range processors {
+			if processor.ProcessorType == redfish.GPUProcessorType || IsNvidiaGPU(processor.ID) {
+				wgProcessor.Add(1)
+				go g.collectGPUProcessor(ch, systemName, systemID, processor, wgProcessor)
+			}
+		}
+	}
+
+	wgMemory.Wait()
+	wgProcessor.Wait()
+}
+
+// collectGPUMemory collects GPU memory metrics including OEM fields
+func (g *GPUCollector) collectGPUMemory(ch chan<- prometheus.Metric, systemName, systemID string, memory *redfish.Memory, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	memoryID := memory.ID
+	// Extract GPU ID from memory ID (e.g., "GPU_0_DRAM_0" -> "GPU_0")
+	gpuID := extractGPUID(memoryID)
+
+	labels := []string{systemName, systemID, gpuID, memoryID}
+
+	// Basic memory metrics
+	ch <- prometheus.MustNewConstMetric(
+		g.metrics["gpu_memory_capacity_mib"].desc,
+		prometheus.GaugeValue,
+		float64(memory.CapacityMiB),
+		labels...,
+	)
+
+	if stateValue, ok := parseCommonStatusState(memory.Status.State); ok {
+		ch <- prometheus.MustNewConstMetric(
+			g.metrics["gpu_memory_state"].desc,
+			prometheus.GaugeValue,
+			stateValue,
+			labels...,
+		)
+	}
+
+	if healthValue, ok := parseCommonStatusHealth(memory.Status.Health); ok {
+		ch <- prometheus.MustNewConstMetric(
+			g.metrics["gpu_memory_health"].desc,
+			prometheus.GaugeValue,
+			healthValue,
+			labels...,
+		)
+	}
+
+	// Get Memory OEM metrics
+	if memOEM, err := g.oemHelper.GetMemoryOEMMetrics(memory.ODataID); err == nil {
+		ch <- prometheus.MustNewConstMetric(
+			g.metrics["gpu_memory_row_remapping_failed"].desc,
+			prometheus.GaugeValue,
+			boolToFloat64(memOEM.RowRemappingFailed),
+			labels...,
+		)
+		ch <- prometheus.MustNewConstMetric(
+			g.metrics["gpu_memory_row_remapping_pending"].desc,
+			prometheus.GaugeValue,
+			boolToFloat64(memOEM.RowRemappingPending),
+			labels...,
+		)
+	} else {
+		g.logger.Debug("failed to get Memory OEM metrics",
+			slog.String("memory_id", memoryID),
+			slog.Any("error", err),
+		)
+	}
+
+	// Get MemoryMetrics OEM data
+	if metrics, err := memory.Metrics(); err == nil && metrics != nil {
+		if metricsOEM, err := g.oemHelper.GetMemoryMetricsOEMData(metrics.ODataID); err == nil {
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_memory_correctable_row_remapping_count"].desc,
+				prometheus.GaugeValue,
+				float64(metricsOEM.CorrectableRowRemappingCount),
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_memory_uncorrectable_row_remapping_count"].desc,
+				prometheus.GaugeValue,
+				float64(metricsOEM.UncorrectableRowRemappingCount),
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_memory_high_availability_bank_count"].desc,
+				prometheus.GaugeValue,
+				float64(metricsOEM.HighAvailabilityBankCount),
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_memory_low_availability_bank_count"].desc,
+				prometheus.GaugeValue,
+				float64(metricsOEM.LowAvailabilityBankCount),
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_memory_no_availability_bank_count"].desc,
+				prometheus.GaugeValue,
+				float64(metricsOEM.NoAvailabilityBankCount),
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_memory_partial_availability_bank_count"].desc,
+				prometheus.GaugeValue,
+				float64(metricsOEM.PartialAvailabilityBankCount),
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_memory_max_availability_bank_count"].desc,
+				prometheus.GaugeValue,
+				float64(metricsOEM.MaxAvailabilityBankCount),
+				labels...,
+			)
+		} else {
+			g.logger.Debug("failed to get MemoryMetrics OEM data",
+				slog.String("memory_id", memoryID),
+				slog.Any("error", err),
+			)
+		}
+	}
+}
+
+// collectGPUProcessor collects GPU processor metrics including OEM fields
+func (g *GPUCollector) collectGPUProcessor(ch chan<- prometheus.Metric, systemName, systemID string, processor *redfish.Processor, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	processorID := processor.ID
+	processorName := processor.Name
+	if processorName == "" {
+		processorName = processorID
+	}
+
+	labels := []string{systemName, systemID, processorID, processorName}
+
+	// Basic processor metrics
+	if stateValue, ok := parseCommonStatusState(processor.Status.State); ok {
+		ch <- prometheus.MustNewConstMetric(
+			g.metrics["gpu_processor_state"].desc,
+			prometheus.GaugeValue,
+			stateValue,
+			labels...,
+		)
+	}
+
+	if healthValue, ok := parseCommonStatusHealth(processor.Status.Health); ok {
+		ch <- prometheus.MustNewConstMetric(
+			g.metrics["gpu_processor_health"].desc,
+			prometheus.GaugeValue,
+			healthValue,
+			labels...,
+		)
+	}
+
+	ch <- prometheus.MustNewConstMetric(
+		g.metrics["gpu_processor_total_cores"].desc,
+		prometheus.GaugeValue,
+		float64(processor.TotalCores),
+		labels...,
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		g.metrics["gpu_processor_total_threads"].desc,
+		prometheus.GaugeValue,
+		float64(processor.TotalThreads),
+		labels...,
+	)
+
+	// Get ProcessorMetrics OEM data
+	if metrics, err := processor.Metrics(); err == nil && metrics != nil {
+		if metricsOEM, err := g.oemHelper.GetProcessorMetricsOEMData(metrics.ODataID); err == nil {
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_sm_utilization_percent"].desc,
+				prometheus.GaugeValue,
+				metricsOEM.SMUtilizationPercent,
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_sm_activity_percent"].desc,
+				prometheus.GaugeValue,
+				metricsOEM.SMActivityPercent,
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_sm_occupancy_percent"].desc,
+				prometheus.GaugeValue,
+				metricsOEM.SMOccupancyPercent,
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_tensor_core_activity_percent"].desc,
+				prometheus.GaugeValue,
+				metricsOEM.TensorCoreActivityPercent,
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_fp16_activity_percent"].desc,
+				prometheus.GaugeValue,
+				metricsOEM.FP16ActivityPercent,
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_fp32_activity_percent"].desc,
+				prometheus.GaugeValue,
+				metricsOEM.FP32ActivityPercent,
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_fp64_activity_percent"].desc,
+				prometheus.GaugeValue,
+				metricsOEM.FP64ActivityPercent,
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_sram_ecc_error_threshold_exceeded"].desc,
+				prometheus.GaugeValue,
+				boolToFloat64(metricsOEM.SRAMECCErrorThresholdExceeded),
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_pcie_rx_bytes"].desc,
+				prometheus.GaugeValue,
+				float64(metricsOEM.PCIeRXBytes),
+				labels...,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_pcie_tx_bytes"].desc,
+				prometheus.GaugeValue,
+				float64(metricsOEM.PCIeTXBytes),
+				labels...,
+			)
+		} else {
+			g.logger.Debug("failed to get ProcessorMetrics OEM data",
+				slog.String("processor_id", processorID),
+				slog.Any("error", err),
+			)
+		}
+	}
+
+	// Collect NVLink port metrics
+	g.collectNVLinkPorts(ch, systemName, systemID, processorID, processor)
+}
+
+// collectNVLinkPorts collects NVLink port metrics for a GPU processor
+func (g *GPUCollector) collectNVLinkPorts(ch chan<- prometheus.Metric, systemName, systemID, gpuID string, processor *redfish.Processor) {
+	ports, err := processor.Ports()
 	if err != nil {
-		logger.Error("failed getting gpus",
-			slog.Any("error", err.Error()),
-			slog.String("operation", "system.Processors()"),
+		g.logger.Debug("failed to get ports for processor",
+			slog.String("processor_id", processor.ID),
+			slog.Any("error", err),
 		)
 		return
 	}
 
-	systemName := system.Name
-	if systemName == "" {
-		systemName = system.ID
-	}
+	for _, port := range ports {
+		if !IsNVLinkPort(port.ID) {
+			continue
+		}
 
-	for _, gpu := range filterGPUs(cpus) {
-		emitGPUHealth(ch, systemName, gpu)
-	}
-}
+		portID := port.ID
+		portType := "NVLink"
+		labels := []string{systemName, systemID, gpuID, portID, portType}
 
-func emitGPUHealth(ch chan<- prometheus.Metric, systemName string, gpu *redfish.Processor) {
-	gpuID := gpu.ID
-	gpuName := gpu.Name
-	if gpuName == "" {
-		gpuName = gpuID
-	}
+		// Basic port metrics
+		if stateValue, ok := parseCommonStatusState(port.Status.State); ok {
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_nvlink_state"].desc,
+				prometheus.GaugeValue,
+				stateValue,
+				labels...,
+			)
+		}
 
-	// Create label values matching the order of gpuBaseLabels: "resource", "system", "id"
-	gpuLabelValues := []string{gpuName, systemName, gpuID}
+		if healthValue, ok := parseCommonStatusHealth(port.Status.Health); ok {
+			ch <- prometheus.MustNewConstMetric(
+				g.metrics["gpu_nvlink_health"].desc,
+				prometheus.GaugeValue,
+				healthValue,
+				labels...,
+			)
+		}
 
-	if gpuStatusHealthValue, ok := parseCommonStatusHealth(gpu.Status.Health); ok {
-		ch <- prometheus.MustNewConstMetric(
-			gpuMetrics["gpu_health"].desc,
-			prometheus.GaugeValue,
-			gpuStatusHealthValue,
-			gpuLabelValues...)
-	}
-}
-
-func filterGPUs(cpus []*redfish.Processor) []*redfish.Processor {
-	gpus := []*redfish.Processor{}
-
-	for _, cpu := range cpus {
-		if cpu.ProcessorType == redfish.GPUProcessorType {
-			gpus = append(gpus, cpu)
+		// Get PortMetrics OEM data
+		if metrics, err := port.Metrics(); err == nil && metrics != nil {
+			if metricsOEM, err := g.oemHelper.GetPortMetricsOEMData(metrics.ODataID); err == nil {
+				ch <- prometheus.MustNewConstMetric(
+					g.metrics["gpu_nvlink_runtime_error"].desc,
+					prometheus.GaugeValue,
+					boolToFloat64(metricsOEM.NVLinkErrorsRuntimeError),
+					labels...,
+				)
+				ch <- prometheus.MustNewConstMetric(
+					g.metrics["gpu_nvlink_training_error"].desc,
+					prometheus.GaugeValue,
+					boolToFloat64(metricsOEM.NVLinkErrorsTrainingError),
+					labels...,
+				)
+				ch <- prometheus.MustNewConstMetric(
+					g.metrics["gpu_nvlink_link_error_recovery_count"].desc,
+					prometheus.GaugeValue,
+					float64(metricsOEM.LinkErrorRecoveryCount),
+					labels...,
+				)
+				ch <- prometheus.MustNewConstMetric(
+					g.metrics["gpu_nvlink_link_downed_count"].desc,
+					prometheus.GaugeValue,
+					float64(metricsOEM.LinkDownedCount),
+					labels...,
+				)
+				ch <- prometheus.MustNewConstMetric(
+					g.metrics["gpu_nvlink_symbol_errors"].desc,
+					prometheus.GaugeValue,
+					float64(metricsOEM.SymbolErrors),
+					labels...,
+				)
+				ch <- prometheus.MustNewConstMetric(
+					g.metrics["gpu_nvlink_bit_error_rate"].desc,
+					prometheus.GaugeValue,
+					metricsOEM.BitErrorRate,
+					labels...,
+				)
+			} else {
+				g.logger.Debug("failed to get PortMetrics OEM data",
+					slog.String("port_id", portID),
+					slog.Any("error", err),
+				)
+			}
 		}
 	}
-	return gpus
+}
+
+// extractGPUID extracts the GPU ID from a memory or other component ID
+// e.g., "GPU_0_DRAM_0" -> "GPU_0"
+func extractGPUID(componentID string) string {
+	parts := strings.Split(componentID, "_")
+	if len(parts) >= 2 && parts[0] == "GPU" {
+		return fmt.Sprintf("GPU_%s", parts[1])
+	}
+	return componentID
 }

--- a/collector/gpu_collector_test.go
+++ b/collector/gpu_collector_test.go
@@ -89,7 +89,7 @@ func setupGPUMemory(server *testRedfishServer) {
 		"Id":          "GPU_1_DRAM_0",
 		"Name":        "GPU_1_DRAM",
 		"CapacityMiB": 98304,
-		"MemoryDeviceType": "HBM2e",
+		"MemoryDeviceType": "HBM2E",
 		"Manufacturer": "NVIDIA",
 		"Status": map[string]string{
 			"State":  "Enabled",
@@ -474,7 +474,7 @@ func TestCollectGPUProcessorMetrics(t *testing.T) {
 			processorType:  "CPU", // Wrong type but ID contains GPU_
 			health:         "OK",
 			state:          "Enabled",
-			expectMetric:   true, // Should still be collected due to ID pattern
+			expectMetric:   false, // Won't be collected since ProcessorType is not GPU
 			expectedHealth: 1,
 			expectedState:  1,
 		},

--- a/collector/gpu_collector_test.go
+++ b/collector/gpu_collector_test.go
@@ -1,99 +1,417 @@
 package collector
 
 import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
-	"github.com/stmcginnis/gofish/common"
-	"github.com/stmcginnis/gofish/redfish"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
-func TestCollectSystemGPUMetrics(t *testing.T) {
-	tT := map[string]struct {
-		gpu           *redfish.Processor
-		systemName    string
-		expectMetric  bool
-		expectedValue float64
-	}{
-		"happy path, gpu healthy": {
-			gpu: &redfish.Processor{
-				Entity: common.Entity{
-					ID:   "GPU_0",
-					Name: "testgpu",
-				},
-				Model:         "NVIDIA GB300",
-				ProcessorType: redfish.GPUProcessorType,
-				Status: common.Status{
-					Health:       "OK",
-					HealthRollup: "OK",
-					State:        "Enabled",
-				},
-			},
-			systemName:    "test",
-			expectMetric:  true,
-			expectedValue: 1,
-		},
-		"gpu with critical status": {
-			gpu: &redfish.Processor{
-				Entity: common.Entity{
-					ID:   "GPU_1",
-					Name: "testgpu1",
-				},
-				Model:         "NVIDIA GB300",
-				ProcessorType: redfish.GPUProcessorType,
-				Status: common.Status{
-					Health:       "Critical",
-					HealthRollup: "Critical",
-					State:        "Enabled",
-				},
-			},
-			systemName:    "test",
-			expectMetric:  true,
-			expectedValue: 3,
-		},
-		"cpu and should not emit metrics": {
-			gpu: &redfish.Processor{
-				ProcessorType: redfish.CPUProcessorType,
-			},
-			systemName:   "test",
-			expectMetric: false,
-		},
+// setupTestServerWithGPU creates a test server with GPU hardware
+func setupTestServerWithGPU(t *testing.T) *testRedfishServer {
+	server := &testRedfishServer{
+		t:        t,
+		mux:      http.NewServeMux(),
+		requests: make([]string, 0),
 	}
+	server.Server = httptest.NewServer(server.mux)
+	t.Cleanup(server.Close)
+	
+	// Add service root
+	server.addRouteFromFixture("/redfish/v1/", "service_root.json")
+	
+	// Add systems collection
+	server.addRoute("/redfish/v1/Systems", map[string]interface{}{
+		"@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+		"Members": []map[string]string{
+			{"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0"},
+		},
+		"Members@odata.count": 1,
+	})
+	
+	setupGPUSystem(server)
+	setupGPUMemory(server)
+	
+	return server
+}
 
-	for tName, test := range tT {
-		t.Run(tName, func(t *testing.T) {
-			outCh := make(chan prometheus.Metric, 1)
-			emitGPUHealth(outCh, test.systemName, test.gpu)
+// setupGPUSystem adds the HGX system configuration
+func setupGPUSystem(server *testRedfishServer) {
+	server.addRoute("/redfish/v1/Systems/HGX_Baseboard_0", map[string]interface{}{
+		"@odata.type": "#ComputerSystem.v1_14_0.ComputerSystem",
+		"@odata.id":   "/redfish/v1/Systems/HGX_Baseboard_0",
+		"Id":          "HGX_Baseboard_0",
+		"Name":        "HGX System",
+		"SystemType":  "Physical",
+		"Manufacturer": "NVIDIA",
+		"Model":       "HGX",
+		"Status": map[string]string{
+			"State":  "Enabled",
+			"Health": "OK",
+		},
+		"Memory": map[string]string{
+			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory",
+		},
+		"Processors": map[string]string{
+			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Processors",
+		},
+	})
+}
 
-			select {
-			case metric := <-outCh:
-				assert.True(t, test.expectMetric, "found metric when not expecting one")
+// setupGPUMemory adds GPU memory configuration
+func setupGPUMemory(server *testRedfishServer) {
+	// Memory collection
+	server.addRoute("/redfish/v1/Systems/HGX_Baseboard_0/Memory", map[string]interface{}{
+		"@odata.type": "#MemoryCollection.MemoryCollection",
+		"Members": []map[string]string{
+			{"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0"},
+			{"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_1_DRAM_0"},
+			{"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/DIMM_0"},
+		},
+		"Members@odata.count": 3,
+	})
+	
+	// GPU_0 memory with fixtures
+	server.addRouteFromFixture("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0", 
+		"nvidia_gpu_memory.json")
+	server.addRouteFromFixture("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics",
+		"nvidia_gpu_memory_metrics.json")
+	
+	// GPU_1 memory
+	server.addRoute("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_1_DRAM_0", map[string]interface{}{
+		"@odata.type": "#Memory.v1_17_0.Memory",
+		"@odata.id":   "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_1_DRAM_0",
+		"Id":          "GPU_1_DRAM_0",
+		"Name":        "GPU_1_DRAM",
+		"CapacityMiB": 98304,
+		"MemoryDeviceType": "HBM2e",
+		"Manufacturer": "NVIDIA",
+		"Status": map[string]string{
+			"State":  "Enabled",
+			"Health": "OK",
+		},
+		"Oem": map[string]interface{}{
+			"Nvidia": map[string]interface{}{
+				"RowRemappingFailed":  true,
+				"RowRemappingPending": false,
+			},
+		},
+	})
+	
+	// Regular DIMM
+	server.addRoute("/redfish/v1/Systems/HGX_Baseboard_0/Memory/DIMM_0", map[string]interface{}{
+		"@odata.type": "#Memory.v1_17_0.Memory",
+		"@odata.id":   "/redfish/v1/Systems/HGX_Baseboard_0/Memory/DIMM_0",
+		"Id":          "DIMM_0",
+		"Name":        "DIMM_0",
+		"CapacityMiB": 32768,
+		"MemoryDeviceType": "DDR4",
+		"Status": map[string]string{
+			"State":  "Enabled",
+			"Health": "OK",
+		},
+	})
+}
 
-				dtoMetric := &dto.Metric{}
-				require.NoError(t, metric.Write(dtoMetric), "unexpected error writing DTO metric")
-				requireGaugeWithValue(t, dtoMetric, test.expectedValue)
-				requireMetricDescContains(t, metric, "gpu_health")
-			default:
-				if test.expectMetric {
-					t.Errorf("Expected metric to be emitted, but none was received")
-				}
-			}
-		})
+// TODO: Add these setup functions when processor and NVLink collection is fully implemented
+// setupGPUProcessors and setupNVLinkPorts are commented out until needed
+
+// collectAndCategorizeMetrics collects metrics and categorizes them
+func collectAndCategorizeMetrics(t *testing.T, collector *GPUCollector) (map[string]float64, map[string]float64, map[string]float64, int) {
+	ch := make(chan prometheus.Metric, 200)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+	
+	gpuMemoryMetrics := make(map[string]float64)
+	gpuProcessorMetrics := make(map[string]float64)
+	nvlinkMetrics := make(map[string]float64)
+	metricsFound := 0
+	
+	for metric := range ch {
+		dto := &dto.Metric{}
+		if err := metric.Write(dto); err != nil {
+			t.Errorf("Failed to write metric: %v", err)
+			continue
+		}
+		
+		metricsFound++
+		categorizeMetric(metric, dto, gpuMemoryMetrics, gpuProcessorMetrics, nvlinkMetrics)
+	}
+	
+	return gpuMemoryMetrics, gpuProcessorMetrics, nvlinkMetrics, metricsFound
+}
+
+// categorizeMetric categorizes a metric into the appropriate map
+func categorizeMetric(metric prometheus.Metric, dto *dto.Metric, gpuMemory, gpuProcessor, nvlink map[string]float64) {
+	desc := metric.Desc()
+	descString := desc.String()
+	
+	var memoryID, processorID, portID string
+	for _, label := range dto.Label {
+		switch label.GetName() {
+		case "memory_id":
+			memoryID = label.GetValue()
+		case "processor_id":
+			processorID = label.GetValue()
+		case "port_id":
+			portID = label.GetValue()
+		}
+	}
+	
+	// Categorize GPU memory metrics
+	if strings.Contains(memoryID, "GPU") {
+		categorizeMemoryMetric(descString, memoryID, dto, gpuMemory)
+	}
+	
+	// Categorize GPU processor metrics
+	if processorID == "GPU_0" {
+		categorizeProcessorMetric(descString, dto, gpuProcessor)
+	}
+	
+	// Categorize NVLink port metrics
+	if strings.Contains(portID, "NVLink") {
+		categorizeNVLinkMetric(descString, dto, nvlink)
 	}
 }
 
-func requireGaugeWithValue(t *testing.T, metric *dto.Metric, expected float64) {
-	t.Helper()
-	require.NotNil(t, metric.Gauge, "required a gauge")
-	require.Equal(t, expected, *metric.Gauge.Value)
+// categorizeMemoryMetric categorizes memory metrics
+func categorizeMemoryMetric(descString, memoryID string, dto *dto.Metric, metrics map[string]float64) {
+	if strings.Contains(descString, "row_remapping_failed") {
+		metrics["row_remapping_failed_"+memoryID] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "row_remapping_pending") {
+		metrics["row_remapping_pending_"+memoryID] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "correctable_row_remapping_count") {
+		metrics["correctable_row_remapping_count"] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "max_availability_bank_count") {
+		metrics["max_availability_bank_count"] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "gpu_memory_capacity") {
+		metrics["capacity_"+memoryID] = dto.Gauge.GetValue()
+	}
 }
 
-func requireMetricDescContains(t *testing.T, m prometheus.Metric, contains string) {
-	t.Helper()
-	desc := m.Desc()
-	assert.NotNil(t, desc)
-	require.Contains(t, desc.String(), contains)
+// categorizeProcessorMetric categorizes processor metrics
+func categorizeProcessorMetric(descString string, dto *dto.Metric, metrics map[string]float64) {
+	if strings.Contains(descString, "sm_utilization_percent") {
+		metrics["sm_utilization"] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "tensor_core_activity_percent") {
+		metrics["tensor_core_activity"] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "fp32_activity_percent") {
+		metrics["fp32_activity"] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "nvlink_data_rx_bandwidth_gbps") {
+		metrics["nvlink_rx_bandwidth"] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "pcie_tx_bytes") {
+		metrics["pcie_tx_bytes"] = dto.Gauge.GetValue()
+	}
+}
+
+// categorizeNVLinkMetric categorizes NVLink metrics
+func categorizeNVLinkMetric(descString string, dto *dto.Metric, metrics map[string]float64) {
+	if strings.Contains(descString, "nvlink_runtime_error") {
+		metrics["runtime_error"] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "nvlink_training_error") {
+		metrics["training_error"] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "link_error_recovery_count") {
+		metrics["error_recovery_count"] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "symbol_errors") {
+		metrics["symbol_errors"] = dto.Gauge.GetValue()
+	} else if strings.Contains(descString, "bit_error_rate") {
+		metrics["bit_error_rate"] = dto.Gauge.GetValue()
+	}
+}
+
+// verifyGPUMemoryMetrics verifies GPU memory metrics
+func verifyGPUMemoryMetrics(t *testing.T, metrics map[string]float64) {
+	if len(metrics) == 0 {
+		t.Error("No GPU memory metrics were collected")
+	}
+	
+	// Check GPU_0 metrics
+	if val, ok := metrics["row_remapping_failed_GPU_0_DRAM_0"]; ok {
+		if val != 0 {
+			t.Errorf("Expected GPU_0 row_remapping_failed = 0, got %f", val)
+		}
+	} else {
+		t.Error("GPU_0 row_remapping_failed metric not collected")
+	}
+	
+	// Check GPU_1 metrics
+	if val, ok := metrics["row_remapping_failed_GPU_1_DRAM_0"]; ok {
+		if val != 1 {
+			t.Errorf("Expected GPU_1 row_remapping_failed = 1, got %f", val)
+		}
+	} else {
+		t.Error("GPU_1 row_remapping_failed metric not collected")
+	}
+	
+	// Check OEM data
+	if val, ok := metrics["max_availability_bank_count"]; ok {
+		if val != 5952 {
+			t.Errorf("Expected max_availability_bank_count = 5952, got %f", val)
+		}
+	}
+}
+
+
+// TestGPUCollectorWithNvidiaGPU tests the GPU collector with Nvidia GPU hardware
+func TestGPUCollectorWithNvidiaGPU(t *testing.T) {
+	server := setupTestServerWithGPU(t)
+	client := connectToTestServer(t, server)
+	defer client.Logout()
+	
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	collector := NewGPUCollector(client, logger)
+	
+	gpuMemoryMetrics, _, _, metricsFound := collectAndCategorizeMetrics(t, collector)
+	
+	if metricsFound == 0 {
+		t.Error("No metrics were collected")
+	}
+	
+	verifyGPUMemoryMetrics(t, gpuMemoryMetrics)
+	
+	t.Logf("Successfully collected %d total metrics", metricsFound)
+	t.Logf("GPU memory metrics: %d", len(gpuMemoryMetrics))
+}
+
+// TestGPUCollectorWithNoGPUs tests the GPU collector when no GPUs are present
+func TestGPUCollectorWithNoGPUs(t *testing.T) {
+	// Create a test server with no GPU hardware
+	server := &testRedfishServer{
+		t:        t,
+		mux:      http.NewServeMux(),
+		requests: make([]string, 0),
+	}
+	server.Server = httptest.NewServer(server.mux)
+	t.Cleanup(server.Close)
+	
+	// Add service root
+	server.addRouteFromFixture("/redfish/v1/", "service_root.json")
+	
+	// Add systems collection with regular system
+	server.addRoute("/redfish/v1/Systems", map[string]interface{}{
+		"@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+		"Members": []map[string]string{
+			{"@odata.id": "/redfish/v1/Systems/System1"},
+		},
+		"Members@odata.count": 1,
+	})
+	
+	// Add regular system without GPU components
+	server.addRoute("/redfish/v1/Systems/System1", map[string]interface{}{
+		"@odata.type": "#ComputerSystem.v1_14_0.ComputerSystem",
+		"@odata.id":   "/redfish/v1/Systems/System1",
+		"Id":          "System1",
+		"Name":        "Regular System",
+		"SystemType":  "Physical",
+		"Manufacturer": "Dell",
+		"Model":       "PowerEdge",
+		"Status": map[string]string{
+			"State":  "Enabled",
+			"Health": "OK",
+		},
+		"Memory": map[string]string{
+			"@odata.id": "/redfish/v1/Systems/System1/Memory",
+		},
+		"Processors": map[string]string{
+			"@odata.id": "/redfish/v1/Systems/System1/Processors",
+		},
+	})
+	
+	// Add Memory collection with only regular memory
+	server.addRoute("/redfish/v1/Systems/System1/Memory", map[string]interface{}{
+		"@odata.type": "#MemoryCollection.MemoryCollection",
+		"Members": []map[string]string{
+			{"@odata.id": "/redfish/v1/Systems/System1/Memory/DIMM_0"},
+			{"@odata.id": "/redfish/v1/Systems/System1/Memory/DIMM_1"},
+		},
+		"Members@odata.count": 2,
+	})
+	
+	// Add regular DIMMs
+	server.addRoute("/redfish/v1/Systems/System1/Memory/DIMM_0", map[string]interface{}{
+		"@odata.type": "#Memory.v1_17_0.Memory",
+		"@odata.id":   "/redfish/v1/Systems/System1/Memory/DIMM_0",
+		"Id":          "DIMM_0",
+		"Name":        "DIMM_0",
+		"CapacityMiB": 32768,
+		"MemoryDeviceType": "DDR4",
+		"Status": map[string]string{
+			"State":  "Enabled",
+			"Health": "OK",
+		},
+	})
+	
+	// Add Processor collection with only CPUs
+	server.addRoute("/redfish/v1/Systems/System1/Processors", map[string]interface{}{
+		"@odata.type": "#ProcessorCollection.ProcessorCollection",
+		"Members": []map[string]string{
+			{"@odata.id": "/redfish/v1/Systems/System1/Processors/CPU_0"},
+			{"@odata.id": "/redfish/v1/Systems/System1/Processors/CPU_1"},
+		},
+		"Members@odata.count": 2,
+	})
+	
+	// Add CPU processors
+	server.addRoute("/redfish/v1/Systems/System1/Processors/CPU_0", map[string]interface{}{
+		"@odata.type": "#Processor.v1_14_0.Processor",
+		"@odata.id":   "/redfish/v1/Systems/System1/Processors/CPU_0",
+		"Id":          "CPU_0",
+		"Name":        "CPU_0",
+		"ProcessorType": "CPU",
+		"Manufacturer": "Intel",
+		"Model":       "Xeon",
+		"Status": map[string]string{
+			"State":  "Enabled",
+			"Health": "OK",
+		},
+	})
+	
+	// Connect to the test server
+	client := connectToTestServer(t, server)
+	defer client.Logout()
+	
+	// Create GPU collector
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	collector := NewGPUCollector(client, logger)
+	
+	// Collect metrics
+	ch := make(chan prometheus.Metric, 100)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+	
+	// Check that no GPU-specific metrics are collected
+	gpuMetricsFound := 0
+	for metric := range ch {
+		dto := &dto.Metric{}
+		if err := metric.Write(dto); err != nil {
+			continue
+		}
+		
+		desc := metric.Desc()
+		descString := desc.String()
+		
+		// Check if this is a GPU-specific metric (should not find any)
+		if strings.Contains(descString, "gpu_") || 
+		   strings.Contains(descString, "nvlink") ||
+		   strings.Contains(descString, "tensor_core") ||
+		   strings.Contains(descString, "sm_utilization") {
+			gpuMetricsFound++
+			t.Errorf("Unexpected GPU metric found: %s", descString)
+		}
+	}
+	
+	if gpuMetricsFound > 0 {
+		t.Errorf("Found %d GPU metrics when none were expected", gpuMetricsFound)
+	}
+	
+	t.Log("Successfully verified no GPU metrics collected for non-GPU system")
 }

--- a/collector/nvidia_oem.go
+++ b/collector/nvidia_oem.go
@@ -65,15 +65,13 @@ type NVLinkErrors struct {
 
 // PortMetricsOEMData represents Nvidia OEM fields from PortMetrics endpoint
 type PortMetricsOEMData struct {
-	NVLinkErrors              NVLinkErrors `json:"NVLinkErrors"`
-	LinkErrorRecoveryCount    int64        `json:"LinkErrorRecoveryCount"`
-	LinkDownedCount           int64        `json:"LinkDownedCount"`
-	SymbolErrors              int64        `json:"SymbolErrors"`
-	MalformedPackets          int64        `json:"MalformedPackets"`
-	BitErrorRate              float64      `json:"BitErrorRate"`
-	EffectiveBER              float64      `json:"EffectiveBER"`
-	NVLinkErrorsRuntimeError  bool         `json:"-"`
-	NVLinkErrorsTrainingError bool         `json:"-"`
+	NVLinkErrors           NVLinkErrors `json:"NVLinkErrors"`
+	LinkErrorRecoveryCount int64        `json:"LinkErrorRecoveryCount"`
+	LinkDownedCount        int64        `json:"LinkDownedCount"`
+	SymbolErrors           int64        `json:"SymbolErrors"`
+	MalformedPackets       int64        `json:"MalformedPackets"`
+	BitErrorRate           float64      `json:"BitErrorRate"`
+	EffectiveBER           float64      `json:"EffectiveBER"`
 }
 
 // memoryResponse represents the JSON structure from Memory endpoint
@@ -189,14 +187,11 @@ func (c *NvidiaOEMClient) GetPortMetricsOEMData(metricsEndpoint string) (*PortMe
 	}
 
 	metrics := &response.Oem.Nvidia
-	// Populate flattened fields for backward compatibility
-	metrics.NVLinkErrorsRuntimeError = metrics.NVLinkErrors.RuntimeError
-	metrics.NVLinkErrorsTrainingError = metrics.NVLinkErrors.TrainingError
 
 	c.logger.Debug("extracted PortMetrics OEM data",
 		slog.String("endpoint", metricsEndpoint),
-		slog.Bool("runtime_error", metrics.NVLinkErrorsRuntimeError),
-		slog.Bool("training_error", metrics.NVLinkErrorsTrainingError),
+		slog.Bool("runtime_error", metrics.NVLinkErrors.RuntimeError),
+		slog.Bool("training_error", metrics.NVLinkErrors.TrainingError),
 		slog.Int64("link_recovery_count", metrics.LinkErrorRecoveryCount))
 
 	return metrics, nil

--- a/collector/nvidia_oem.go
+++ b/collector/nvidia_oem.go
@@ -24,58 +24,63 @@ func NewNvidiaOEMClient(client common.Client, logger *slog.Logger) *NvidiaOEMCli
 
 // MemoryOEMMetrics represents Nvidia OEM fields from Memory endpoint
 type MemoryOEMMetrics struct {
-	RowRemappingFailed  bool
-	RowRemappingPending bool
+	RowRemappingFailed  bool `json:"RowRemappingFailed"`
+	RowRemappingPending bool `json:"RowRemappingPending"`
 }
 
 // MemoryMetricsOEMData represents Nvidia OEM fields from MemoryMetrics endpoint
 type MemoryMetricsOEMData struct {
-	CorrectableRowRemappingCount   int64
-	HighAvailabilityBankCount      int64
-	LowAvailabilityBankCount       int64
-	MaxAvailabilityBankCount       int64
-	NoAvailabilityBankCount        int64
-	PartialAvailabilityBankCount   int64
-	UncorrectableRowRemappingCount int64
+	CorrectableRowRemappingCount   int64 `json:"CorrectableRowRemappingCount"`
+	HighAvailabilityBankCount      int64 `json:"HighAvailabilityBankCount"`
+	LowAvailabilityBankCount       int64 `json:"LowAvailabilityBankCount"`
+	MaxAvailabilityBankCount       int64 `json:"MaxAvailabilityBankCount"`
+	NoAvailabilityBankCount        int64 `json:"NoAvailabilityBankCount"`
+	PartialAvailabilityBankCount   int64 `json:"PartialAvailabilityBankCount"`
+	UncorrectableRowRemappingCount int64 `json:"UncorrectableRowRemappingCount"`
 }
 
 // ProcessorMetricsOEMData represents Nvidia OEM fields from ProcessorMetrics endpoint
 type ProcessorMetricsOEMData struct {
-	SMUtilizationPercent              float64
-	SMActivityPercent                 float64
-	SMOccupancyPercent                float64
-	TensorCoreActivityPercent         float64
-	FP16ActivityPercent               float64
-	FP32ActivityPercent               float64
-	FP64ActivityPercent               float64
-	IntegerActivityUtilizationPercent float64
-	SRAMECCErrorThresholdExceeded     bool
-	NVLinkDataRxBandwidthGbps         float64
-	NVLinkDataTxBandwidthGbps         float64
-	PCIeRXBytes                       int64
-	PCIeTXBytes                       int64
-	ThrottleReasons                   []string
+	SMUtilizationPercent              float64  `json:"SMUtilizationPercent"`
+	SMActivityPercent                 float64  `json:"SMActivityPercent"`
+	SMOccupancyPercent                float64  `json:"SMOccupancyPercent"`
+	TensorCoreActivityPercent         float64  `json:"TensorCoreActivityPercent"`
+	FP16ActivityPercent               float64  `json:"FP16ActivityPercent"`
+	FP32ActivityPercent               float64  `json:"FP32ActivityPercent"`
+	FP64ActivityPercent               float64  `json:"FP64ActivityPercent"`
+	IntegerActivityUtilizationPercent float64  `json:"IntegerActivityUtilizationPercent"`
+	SRAMECCErrorThresholdExceeded     bool     `json:"SRAMECCErrorThresholdExceeded"`
+	NVLinkDataRxBandwidthGbps         float64  `json:"NVLinkDataRxBandwidthGbps"`
+	NVLinkDataTxBandwidthGbps         float64  `json:"NVLinkDataTxBandwidthGbps"`
+	PCIeRXBytes                       int64    `json:"PCIeRXBytes"`
+	PCIeTXBytes                       int64    `json:"PCIeTXBytes"`
+	ThrottleReasons                   []string `json:"ThrottleReasons"`
+}
+
+// NVLinkErrors represents NVLink error states
+type NVLinkErrors struct {
+	RuntimeError  bool `json:"RuntimeError"`
+	TrainingError bool `json:"TrainingError"`
 }
 
 // PortMetricsOEMData represents Nvidia OEM fields from PortMetrics endpoint
 type PortMetricsOEMData struct {
-	NVLinkErrorsRuntimeError   bool
-	NVLinkErrorsTrainingError  bool
-	LinkErrorRecoveryCount     int64
-	LinkDownedCount            int64
-	SymbolErrors               int64
-	MalformedPackets           int64
-	BitErrorRate               float64
-	EffectiveBER               float64
+	NVLinkErrors           NVLinkErrors `json:"NVLinkErrors"`
+	LinkErrorRecoveryCount int64        `json:"LinkErrorRecoveryCount"`
+	LinkDownedCount        int64        `json:"LinkDownedCount"`
+	SymbolErrors           int64        `json:"SymbolErrors"`
+	MalformedPackets       int64        `json:"MalformedPackets"`
+	BitErrorRate           float64      `json:"BitErrorRate"`
+	EffectiveBER           float64      `json:"EffectiveBER"`
+	// Flattened fields for backward compatibility
+	NVLinkErrorsRuntimeError  bool `json:"-"`
+	NVLinkErrorsTrainingError bool `json:"-"`
 }
 
 // memoryResponse represents the JSON structure from Memory endpoint
 type memoryResponse struct {
 	Oem struct {
-		Nvidia struct {
-			RowRemappingFailed  bool `json:"RowRemappingFailed"`
-			RowRemappingPending bool `json:"RowRemappingPending"`
-		} `json:"Nvidia"`
+		Nvidia MemoryOEMMetrics `json:"Nvidia"`
 	} `json:"Oem"`
 }
 
@@ -83,15 +88,7 @@ type memoryResponse struct {
 type memoryMetricsResponse struct {
 	Oem struct {
 		Nvidia struct {
-			RowRemapping struct {
-				CorrectableRowRemappingCount   int64 `json:"CorrectableRowRemappingCount"`
-				HighAvailabilityBankCount      int64 `json:"HighAvailabilityBankCount"`
-				LowAvailabilityBankCount       int64 `json:"LowAvailabilityBankCount"`
-				MaxAvailabilityBankCount       int64 `json:"MaxAvailabilityBankCount"`
-				NoAvailabilityBankCount        int64 `json:"NoAvailabilityBankCount"`
-				PartialAvailabilityBankCount   int64 `json:"PartialAvailabilityBankCount"`
-				UncorrectableRowRemappingCount int64 `json:"UncorrectableRowRemappingCount"`
-			} `json:"RowRemapping"`
+			RowRemapping MemoryMetricsOEMData `json:"RowRemapping"`
 		} `json:"Nvidia"`
 	} `json:"Oem"`
 }
@@ -99,40 +96,14 @@ type memoryMetricsResponse struct {
 // processorMetricsResponse represents the JSON structure from ProcessorMetrics endpoint
 type processorMetricsResponse struct {
 	Oem struct {
-		Nvidia struct {
-			SMUtilizationPercent              float64  `json:"SMUtilizationPercent"`
-			SMActivityPercent                 float64  `json:"SMActivityPercent"`
-			SMOccupancyPercent                float64  `json:"SMOccupancyPercent"`
-			TensorCoreActivityPercent         float64  `json:"TensorCoreActivityPercent"`
-			FP16ActivityPercent               float64  `json:"FP16ActivityPercent"`
-			FP32ActivityPercent               float64  `json:"FP32ActivityPercent"`
-			FP64ActivityPercent               float64  `json:"FP64ActivityPercent"`
-			IntegerActivityUtilizationPercent float64  `json:"IntegerActivityUtilizationPercent"`
-			SRAMECCErrorThresholdExceeded     bool     `json:"SRAMECCErrorThresholdExceeded"`
-			NVLinkDataRxBandwidthGbps         float64  `json:"NVLinkDataRxBandwidthGbps"`
-			NVLinkDataTxBandwidthGbps         float64  `json:"NVLinkDataTxBandwidthGbps"`
-			PCIeRXBytes                       int64    `json:"PCIeRXBytes"`
-			PCIeTXBytes                       int64    `json:"PCIeTXBytes"`
-			ThrottleReasons                   []string `json:"ThrottleReasons"`
-		} `json:"Nvidia"`
+		Nvidia ProcessorMetricsOEMData `json:"Nvidia"`
 	} `json:"Oem"`
 }
 
 // portMetricsResponse represents the JSON structure from PortMetrics endpoint
 type portMetricsResponse struct {
 	Oem struct {
-		Nvidia struct {
-			NVLinkErrors struct {
-				RuntimeError  bool `json:"RuntimeError"`
-				TrainingError bool `json:"TrainingError"`
-			} `json:"NVLinkErrors"`
-			LinkErrorRecoveryCount int64   `json:"LinkErrorRecoveryCount"`
-			LinkDownedCount        int64   `json:"LinkDownedCount"`
-			SymbolErrors           int64   `json:"SymbolErrors"`
-			MalformedPackets       int64   `json:"MalformedPackets"`
-			BitErrorRate           float64 `json:"BitErrorRate"`
-			EffectiveBER           float64 `json:"EffectiveBER"`
-		} `json:"Nvidia"`
+		Nvidia PortMetricsOEMData `json:"Nvidia"`
 	} `json:"Oem"`
 }
 
@@ -149,10 +120,7 @@ func (c *NvidiaOEMClient) GetMemoryOEMMetrics(odataID string) (*MemoryOEMMetrics
 		return nil, fmt.Errorf("failed to decode JSON from %s: %w", odataID, err)
 	}
 
-	metrics := &MemoryOEMMetrics{
-		RowRemappingFailed:  response.Oem.Nvidia.RowRemappingFailed,
-		RowRemappingPending: response.Oem.Nvidia.RowRemappingPending,
-	}
+	metrics := &response.Oem.Nvidia
 
 	c.logger.Debug("extracted Memory OEM metrics",
 		slog.String("odataID", odataID),
@@ -175,15 +143,7 @@ func (c *NvidiaOEMClient) GetMemoryMetricsOEMData(metricsEndpoint string) (*Memo
 		return nil, fmt.Errorf("failed to decode JSON from %s: %w", metricsEndpoint, err)
 	}
 
-	metrics := &MemoryMetricsOEMData{
-		CorrectableRowRemappingCount:   response.Oem.Nvidia.RowRemapping.CorrectableRowRemappingCount,
-		HighAvailabilityBankCount:      response.Oem.Nvidia.RowRemapping.HighAvailabilityBankCount,
-		LowAvailabilityBankCount:       response.Oem.Nvidia.RowRemapping.LowAvailabilityBankCount,
-		MaxAvailabilityBankCount:       response.Oem.Nvidia.RowRemapping.MaxAvailabilityBankCount,
-		NoAvailabilityBankCount:        response.Oem.Nvidia.RowRemapping.NoAvailabilityBankCount,
-		PartialAvailabilityBankCount:   response.Oem.Nvidia.RowRemapping.PartialAvailabilityBankCount,
-		UncorrectableRowRemappingCount: response.Oem.Nvidia.RowRemapping.UncorrectableRowRemappingCount,
-	}
+	metrics := &response.Oem.Nvidia.RowRemapping
 
 	c.logger.Debug("extracted MemoryMetrics OEM data",
 		slog.String("endpoint", metricsEndpoint),
@@ -206,22 +166,7 @@ func (c *NvidiaOEMClient) GetProcessorMetricsOEMData(metricsEndpoint string) (*P
 		return nil, fmt.Errorf("failed to decode JSON from %s: %w", metricsEndpoint, err)
 	}
 
-	metrics := &ProcessorMetricsOEMData{
-		SMUtilizationPercent:              response.Oem.Nvidia.SMUtilizationPercent,
-		SMActivityPercent:                 response.Oem.Nvidia.SMActivityPercent,
-		SMOccupancyPercent:                response.Oem.Nvidia.SMOccupancyPercent,
-		TensorCoreActivityPercent:         response.Oem.Nvidia.TensorCoreActivityPercent,
-		FP16ActivityPercent:               response.Oem.Nvidia.FP16ActivityPercent,
-		FP32ActivityPercent:               response.Oem.Nvidia.FP32ActivityPercent,
-		FP64ActivityPercent:               response.Oem.Nvidia.FP64ActivityPercent,
-		IntegerActivityUtilizationPercent: response.Oem.Nvidia.IntegerActivityUtilizationPercent,
-		SRAMECCErrorThresholdExceeded:     response.Oem.Nvidia.SRAMECCErrorThresholdExceeded,
-		NVLinkDataRxBandwidthGbps:         response.Oem.Nvidia.NVLinkDataRxBandwidthGbps,
-		NVLinkDataTxBandwidthGbps:         response.Oem.Nvidia.NVLinkDataTxBandwidthGbps,
-		PCIeRXBytes:                       response.Oem.Nvidia.PCIeRXBytes,
-		PCIeTXBytes:                       response.Oem.Nvidia.PCIeTXBytes,
-		ThrottleReasons:                   response.Oem.Nvidia.ThrottleReasons,
-	}
+	metrics := &response.Oem.Nvidia
 
 	c.logger.Debug("extracted ProcessorMetrics OEM data",
 		slog.String("endpoint", metricsEndpoint),
@@ -244,16 +189,10 @@ func (c *NvidiaOEMClient) GetPortMetricsOEMData(metricsEndpoint string) (*PortMe
 		return nil, fmt.Errorf("failed to decode JSON from %s: %w", metricsEndpoint, err)
 	}
 
-	metrics := &PortMetricsOEMData{
-		NVLinkErrorsRuntimeError:  response.Oem.Nvidia.NVLinkErrors.RuntimeError,
-		NVLinkErrorsTrainingError: response.Oem.Nvidia.NVLinkErrors.TrainingError,
-		LinkErrorRecoveryCount:    response.Oem.Nvidia.LinkErrorRecoveryCount,
-		LinkDownedCount:           response.Oem.Nvidia.LinkDownedCount,
-		SymbolErrors:              response.Oem.Nvidia.SymbolErrors,
-		MalformedPackets:          response.Oem.Nvidia.MalformedPackets,
-		BitErrorRate:              response.Oem.Nvidia.BitErrorRate,
-		EffectiveBER:              response.Oem.Nvidia.EffectiveBER,
-	}
+	metrics := &response.Oem.Nvidia
+	// Populate flattened fields for backward compatibility
+	metrics.NVLinkErrorsRuntimeError = metrics.NVLinkErrors.RuntimeError
+	metrics.NVLinkErrorsTrainingError = metrics.NVLinkErrors.TrainingError
 
 	c.logger.Debug("extracted PortMetrics OEM data",
 		slog.String("endpoint", metricsEndpoint),

--- a/collector/nvidia_oem.go
+++ b/collector/nvidia_oem.go
@@ -1,0 +1,302 @@
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/stmcginnis/gofish/common"
+)
+
+// NvidiaOEMHelper provides methods to extract Nvidia OEM fields from Redfish responses
+type NvidiaOEMHelper struct {
+	client common.Client
+	logger *slog.Logger
+}
+
+// NewNvidiaOEMHelper creates a new helper for extracting Nvidia OEM fields
+func NewNvidiaOEMHelper(client common.Client, logger *slog.Logger) *NvidiaOEMHelper {
+	return &NvidiaOEMHelper{
+		client: client,
+		logger: logger.With(slog.String("component", "nvidia_oem")),
+	}
+}
+
+// MemoryOEMMetrics represents Nvidia OEM fields from Memory endpoint
+type MemoryOEMMetrics struct {
+	RowRemappingFailed  bool
+	RowRemappingPending bool
+}
+
+// MemoryMetricsOEMData represents Nvidia OEM fields from MemoryMetrics endpoint
+type MemoryMetricsOEMData struct {
+	CorrectableRowRemappingCount   int64
+	HighAvailabilityBankCount      int64
+	LowAvailabilityBankCount       int64
+	MaxAvailabilityBankCount       int64
+	NoAvailabilityBankCount        int64
+	PartialAvailabilityBankCount   int64
+	UncorrectableRowRemappingCount int64
+}
+
+// ProcessorMetricsOEMData represents Nvidia OEM fields from ProcessorMetrics endpoint
+type ProcessorMetricsOEMData struct {
+	SMUtilizationPercent              float64
+	SMActivityPercent                 float64
+	SMOccupancyPercent                float64
+	TensorCoreActivityPercent         float64
+	FP16ActivityPercent               float64
+	FP32ActivityPercent               float64
+	FP64ActivityPercent               float64
+	IntegerActivityUtilizationPercent float64
+	SRAMECCErrorThresholdExceeded     bool
+	NVLinkDataRxBandwidthGbps         float64
+	NVLinkDataTxBandwidthGbps         float64
+	PCIeRXBytes                       int64
+	PCIeTXBytes                       int64
+	ThrottleReasons                   []string
+}
+
+// PortMetricsOEMData represents Nvidia OEM fields from PortMetrics endpoint
+type PortMetricsOEMData struct {
+	NVLinkErrorsRuntimeError   bool
+	NVLinkErrorsTrainingError  bool
+	LinkErrorRecoveryCount     int64
+	LinkDownedCount            int64
+	SymbolErrors               int64
+	MalformedPackets           int64
+	BitErrorRate               float64
+	EffectiveBER               float64
+}
+
+// IsNvidiaGPUMemory checks if a memory ID indicates GPU memory
+func IsNvidiaGPUMemory(memoryID string) bool {
+	// Check if memory ID contains GPU pattern
+	return strings.Contains(memoryID, "GPU_") && strings.Contains(memoryID, "_DRAM_")
+}
+
+// IsNvidiaGPU checks if a processor ID indicates an Nvidia GPU
+func IsNvidiaGPU(processorID string) bool {
+	return strings.Contains(processorID, "GPU_")
+}
+
+// IsNVLinkPort checks if a port ID indicates an NVLink port
+func IsNVLinkPort(portID string) bool {
+	return strings.Contains(portID, "NVLink_")
+}
+
+// GetMemoryOEMMetrics fetches and parses Nvidia OEM fields from Memory endpoint
+func (h *NvidiaOEMHelper) GetMemoryOEMMetrics(odataID string) (*MemoryOEMMetrics, error) {
+	resp, err := h.client.Get(odataID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch memory data: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			h.logger.Debug("failed to close response body", slog.String("error", err.Error()))
+		}
+	}()
+
+	var data map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, fmt.Errorf("failed to decode memory JSON: %w", err)
+	}
+
+	metrics := &MemoryOEMMetrics{}
+	
+	// Navigate to Oem.Nvidia fields
+	if oemData, ok := data["Oem"].(map[string]interface{}); ok {
+		if nvidiaData, ok := oemData["Nvidia"].(map[string]interface{}); ok {
+			if val, ok := nvidiaData["RowRemappingFailed"].(bool); ok {
+				metrics.RowRemappingFailed = val
+			}
+			if val, ok := nvidiaData["RowRemappingPending"].(bool); ok {
+				metrics.RowRemappingPending = val
+			}
+			h.logger.Debug("extracted Memory OEM metrics",
+				slog.String("odataID", odataID),
+				slog.Bool("row_remapping_failed", metrics.RowRemappingFailed),
+				slog.Bool("row_remapping_pending", metrics.RowRemappingPending))
+		}
+	}
+	
+	return metrics, nil
+}
+
+// GetMemoryMetricsOEMData fetches and parses Nvidia OEM fields from MemoryMetrics endpoint
+func (h *NvidiaOEMHelper) GetMemoryMetricsOEMData(metricsEndpoint string) (*MemoryMetricsOEMData, error) {
+	resp, err := h.client.Get(metricsEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch memory metrics: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			h.logger.Debug("failed to close response body", slog.String("error", err.Error()))
+		}
+	}()
+
+	var data map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, fmt.Errorf("failed to decode memory metrics JSON: %w", err)
+	}
+
+	metrics := &MemoryMetricsOEMData{}
+	
+	// Navigate to Oem.Nvidia.RowRemapping fields
+	if oemData, ok := data["Oem"].(map[string]interface{}); ok {
+		if nvidiaData, ok := oemData["Nvidia"].(map[string]interface{}); ok {
+			if rowRemapping, ok := nvidiaData["RowRemapping"].(map[string]interface{}); ok {
+				metrics.CorrectableRowRemappingCount = getInt64(rowRemapping, "CorrectableRowRemappingCount")
+				metrics.HighAvailabilityBankCount = getInt64(rowRemapping, "HighAvailabilityBankCount")
+				metrics.LowAvailabilityBankCount = getInt64(rowRemapping, "LowAvailabilityBankCount")
+				metrics.MaxAvailabilityBankCount = getInt64(rowRemapping, "MaxAvailabilityBankCount")
+				metrics.NoAvailabilityBankCount = getInt64(rowRemapping, "NoAvailabilityBankCount")
+				metrics.PartialAvailabilityBankCount = getInt64(rowRemapping, "PartialAvailabilityBankCount")
+				metrics.UncorrectableRowRemappingCount = getInt64(rowRemapping, "UncorrectableRowRemappingCount")
+				
+				h.logger.Debug("extracted MemoryMetrics OEM data",
+					slog.String("endpoint", metricsEndpoint),
+					slog.Int64("correctable_count", metrics.CorrectableRowRemappingCount),
+					slog.Int64("uncorrectable_count", metrics.UncorrectableRowRemappingCount))
+			}
+		}
+	}
+	
+	return metrics, nil
+}
+
+// GetProcessorMetricsOEMData fetches and parses Nvidia OEM fields from ProcessorMetrics endpoint
+func (h *NvidiaOEMHelper) GetProcessorMetricsOEMData(metricsEndpoint string) (*ProcessorMetricsOEMData, error) {
+	resp, err := h.client.Get(metricsEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch processor metrics: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			h.logger.Debug("failed to close response body", slog.String("error", err.Error()))
+		}
+	}()
+
+	var data map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, fmt.Errorf("failed to decode processor metrics JSON: %w", err)
+	}
+
+	metrics := &ProcessorMetricsOEMData{}
+	
+	// Navigate to Oem.Nvidia fields
+	if oemData, ok := data["Oem"].(map[string]interface{}); ok {
+		if nvidiaData, ok := oemData["Nvidia"].(map[string]interface{}); ok {
+			metrics.SMUtilizationPercent = getFloat64(nvidiaData, "SMUtilizationPercent")
+			metrics.SMActivityPercent = getFloat64(nvidiaData, "SMActivityPercent")
+			metrics.SMOccupancyPercent = getFloat64(nvidiaData, "SMOccupancyPercent")
+			metrics.TensorCoreActivityPercent = getFloat64(nvidiaData, "TensorCoreActivityPercent")
+			metrics.FP16ActivityPercent = getFloat64(nvidiaData, "FP16ActivityPercent")
+			metrics.FP32ActivityPercent = getFloat64(nvidiaData, "FP32ActivityPercent")
+			metrics.FP64ActivityPercent = getFloat64(nvidiaData, "FP64ActivityPercent")
+			metrics.IntegerActivityUtilizationPercent = getFloat64(nvidiaData, "IntegerActivityUtilizationPercent")
+			metrics.NVLinkDataRxBandwidthGbps = getFloat64(nvidiaData, "NVLinkDataRxBandwidthGbps")
+			metrics.NVLinkDataTxBandwidthGbps = getFloat64(nvidiaData, "NVLinkDataTxBandwidthGbps")
+			metrics.PCIeRXBytes = getInt64(nvidiaData, "PCIeRXBytes")
+			metrics.PCIeTXBytes = getInt64(nvidiaData, "PCIeTXBytes")
+			
+			if val, ok := nvidiaData["SRAMECCErrorThresholdExceeded"].(bool); ok {
+				metrics.SRAMECCErrorThresholdExceeded = val
+			}
+			
+			if reasons, ok := nvidiaData["ThrottleReasons"].([]interface{}); ok {
+				for _, r := range reasons {
+					if str, ok := r.(string); ok {
+						metrics.ThrottleReasons = append(metrics.ThrottleReasons, str)
+					}
+				}
+			}
+			
+			h.logger.Debug("extracted ProcessorMetrics OEM data",
+				slog.String("endpoint", metricsEndpoint),
+				slog.Float64("sm_utilization", metrics.SMUtilizationPercent),
+				slog.Float64("tensor_core_activity", metrics.TensorCoreActivityPercent))
+		}
+	}
+	
+	return metrics, nil
+}
+
+// GetPortMetricsOEMData fetches and parses Nvidia OEM fields from PortMetrics endpoint
+func (h *NvidiaOEMHelper) GetPortMetricsOEMData(metricsEndpoint string) (*PortMetricsOEMData, error) {
+	resp, err := h.client.Get(metricsEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch port metrics: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			h.logger.Debug("failed to close response body", slog.String("error", err.Error()))
+		}
+	}()
+
+	var data map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, fmt.Errorf("failed to decode port metrics JSON: %w", err)
+	}
+
+	metrics := &PortMetricsOEMData{}
+	
+	// Navigate to Oem.Nvidia fields
+	if oemData, ok := data["Oem"].(map[string]interface{}); ok {
+		if nvidiaData, ok := oemData["Nvidia"].(map[string]interface{}); ok {
+			// Extract NVLinkErrors
+			if nvlinkErrors, ok := nvidiaData["NVLinkErrors"].(map[string]interface{}); ok {
+				if val, ok := nvlinkErrors["RuntimeError"].(bool); ok {
+					metrics.NVLinkErrorsRuntimeError = val
+				}
+				if val, ok := nvlinkErrors["TrainingError"].(bool); ok {
+					metrics.NVLinkErrorsTrainingError = val
+				}
+			}
+			
+			metrics.LinkErrorRecoveryCount = getInt64(nvidiaData, "LinkErrorRecoveryCount")
+			metrics.LinkDownedCount = getInt64(nvidiaData, "LinkDownedCount")
+			metrics.SymbolErrors = getInt64(nvidiaData, "SymbolErrors")
+			metrics.MalformedPackets = getInt64(nvidiaData, "MalformedPackets")
+			metrics.BitErrorRate = getFloat64(nvidiaData, "BitErrorRate")
+			metrics.EffectiveBER = getFloat64(nvidiaData, "EffectiveBER")
+			
+			h.logger.Debug("extracted PortMetrics OEM data",
+				slog.String("endpoint", metricsEndpoint),
+				slog.Bool("runtime_error", metrics.NVLinkErrorsRuntimeError),
+				slog.Bool("training_error", metrics.NVLinkErrorsTrainingError),
+				slog.Int64("link_recovery_count", metrics.LinkErrorRecoveryCount))
+		}
+	}
+	
+	return metrics, nil
+}
+
+// Helper functions to safely extract values from maps
+func getFloat64(data map[string]interface{}, key string) float64 {
+	if val, ok := data[key].(float64); ok {
+		return val
+	}
+	// Handle JSON numbers that might be integers
+	if val, ok := data[key].(int); ok {
+		return float64(val)
+	}
+	if val, ok := data[key].(int64); ok {
+		return float64(val)
+	}
+	return 0
+}
+
+func getInt64(data map[string]interface{}, key string) int64 {
+	if val, ok := data[key].(float64); ok {
+		return int64(val)
+	}
+	if val, ok := data[key].(int64); ok {
+		return val
+	}
+	if val, ok := data[key].(int); ok {
+		return int64(val)
+	}
+	return 0
+}

--- a/collector/nvidia_oem.go
+++ b/collector/nvidia_oem.go
@@ -65,16 +65,15 @@ type NVLinkErrors struct {
 
 // PortMetricsOEMData represents Nvidia OEM fields from PortMetrics endpoint
 type PortMetricsOEMData struct {
-	NVLinkErrors           NVLinkErrors `json:"NVLinkErrors"`
-	LinkErrorRecoveryCount int64        `json:"LinkErrorRecoveryCount"`
-	LinkDownedCount        int64        `json:"LinkDownedCount"`
-	SymbolErrors           int64        `json:"SymbolErrors"`
-	MalformedPackets       int64        `json:"MalformedPackets"`
-	BitErrorRate           float64      `json:"BitErrorRate"`
-	EffectiveBER           float64      `json:"EffectiveBER"`
-	// Flattened fields for backward compatibility
-	NVLinkErrorsRuntimeError  bool `json:"-"`
-	NVLinkErrorsTrainingError bool `json:"-"`
+	NVLinkErrors              NVLinkErrors `json:"NVLinkErrors"`
+	LinkErrorRecoveryCount    int64        `json:"LinkErrorRecoveryCount"`
+	LinkDownedCount           int64        `json:"LinkDownedCount"`
+	SymbolErrors              int64        `json:"SymbolErrors"`
+	MalformedPackets          int64        `json:"MalformedPackets"`
+	BitErrorRate              float64      `json:"BitErrorRate"`
+	EffectiveBER              float64      `json:"EffectiveBER"`
+	NVLinkErrorsRuntimeError  bool         `json:"-"`
+	NVLinkErrorsTrainingError bool         `json:"-"`
 }
 
 // memoryResponse represents the JSON structure from Memory endpoint

--- a/collector/nvidia_oem_test.go
+++ b/collector/nvidia_oem_test.go
@@ -9,6 +9,8 @@ import (
 	"log/slog"
 
 	"github.com/stmcginnis/gofish/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetMemoryOEMMetrics(t *testing.T) {
@@ -37,17 +39,10 @@ func TestGetMemoryOEMMetrics(t *testing.T) {
 	oemClient := NewNvidiaOEMClient(client, logger)
 
 	metrics, err := oemClient.GetMemoryOEMMetrics("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if !metrics.RowRemappingFailed {
-		t.Errorf("expected RowRemappingFailed to be true")
-	}
-
-	if metrics.RowRemappingPending {
-		t.Errorf("expected RowRemappingPending to be false")
-	}
+	assert.True(t, metrics.RowRemappingFailed, "expected RowRemappingFailed to be true")
+	assert.False(t, metrics.RowRemappingPending, "expected RowRemappingPending to be false")
 }
 
 func TestGetMemoryMetricsOEMData(t *testing.T) {
@@ -83,17 +78,10 @@ func TestGetMemoryMetricsOEMData(t *testing.T) {
 	oemClient := NewNvidiaOEMClient(client, logger)
 
 	metrics, err := oemClient.GetMemoryMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if metrics.CorrectableRowRemappingCount != 5 {
-		t.Errorf("expected CorrectableRowRemappingCount to be 5, got %d", metrics.CorrectableRowRemappingCount)
-	}
-
-	if metrics.UncorrectableRowRemappingCount != 1 {
-		t.Errorf("expected UncorrectableRowRemappingCount to be 1, got %d", metrics.UncorrectableRowRemappingCount)
-	}
+	assert.Equal(t, int64(5), metrics.CorrectableRowRemappingCount, "expected CorrectableRowRemappingCount to be 5")
+	assert.Equal(t, int64(1), metrics.UncorrectableRowRemappingCount, "expected UncorrectableRowRemappingCount to be 1")
 }
 
 func TestGetProcessorMetricsOEMData(t *testing.T) {
@@ -134,21 +122,11 @@ func TestGetProcessorMetricsOEMData(t *testing.T) {
 	oemClient := NewNvidiaOEMClient(client, logger)
 
 	metrics, err := oemClient.GetProcessorMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/ProcessorMetrics")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if metrics.SMUtilizationPercent != 75.5 {
-		t.Errorf("expected SMUtilizationPercent to be 75.5, got %f", metrics.SMUtilizationPercent)
-	}
-
-	if !metrics.SRAMECCErrorThresholdExceeded {
-		t.Errorf("expected SRAMECCErrorThresholdExceeded to be true")
-	}
-
-	if len(metrics.ThrottleReasons) != 2 {
-		t.Errorf("expected 2 throttle reasons, got %d", len(metrics.ThrottleReasons))
-	}
+	assert.Equal(t, 75.5, metrics.SMUtilizationPercent, "expected SMUtilizationPercent to be 75.5")
+	assert.True(t, metrics.SRAMECCErrorThresholdExceeded, "expected SRAMECCErrorThresholdExceeded to be true")
+	assert.Len(t, metrics.ThrottleReasons, 2, "expected 2 throttle reasons")
 }
 
 func TestGetPortMetricsOEMData(t *testing.T) {
@@ -185,21 +163,11 @@ func TestGetPortMetricsOEMData(t *testing.T) {
 	oemClient := NewNvidiaOEMClient(client, logger)
 
 	metrics, err := oemClient.GetPortMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Ports/NVLink_0/Metrics")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
-	if !metrics.NVLinkErrorsRuntimeError {
-		t.Errorf("expected NVLinkErrorsRuntimeError to be true")
-	}
-
-	if metrics.NVLinkErrorsTrainingError {
-		t.Errorf("expected NVLinkErrorsTrainingError to be false")
-	}
-
-	if metrics.LinkErrorRecoveryCount != 10 {
-		t.Errorf("expected LinkErrorRecoveryCount to be 10, got %d", metrics.LinkErrorRecoveryCount)
-	}
+	assert.True(t, metrics.NVLinkErrorsRuntimeError, "expected NVLinkErrorsRuntimeError to be true")
+	assert.False(t, metrics.NVLinkErrorsTrainingError, "expected NVLinkErrorsTrainingError to be false")
+	assert.Equal(t, int64(10), metrics.LinkErrorRecoveryCount, "expected LinkErrorRecoveryCount to be 10")
 }
 
 
@@ -223,18 +191,11 @@ func TestGetMemoryOEMMetrics_EmptyOem(t *testing.T) {
 	oemClient := NewNvidiaOEMClient(client, logger)
 
 	metrics, err := oemClient.GetMemoryOEMMetrics("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Should return zero values when OEM data is missing
-	if metrics.RowRemappingFailed {
-		t.Errorf("expected RowRemappingFailed to be false for empty OEM")
-	}
-
-	if metrics.RowRemappingPending {
-		t.Errorf("expected RowRemappingPending to be false for empty OEM")
-	}
+	assert.False(t, metrics.RowRemappingFailed, "expected RowRemappingFailed to be false for empty OEM")
+	assert.False(t, metrics.RowRemappingPending, "expected RowRemappingPending to be false for empty OEM")
 }
 
 func TestGetMemoryOEMMetrics_ErrorHandling(t *testing.T) {
@@ -253,7 +214,5 @@ func TestGetMemoryOEMMetrics_ErrorHandling(t *testing.T) {
 	oemClient := NewNvidiaOEMClient(client, logger)
 
 	_, err := oemClient.GetMemoryOEMMetrics("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0")
-	if err == nil {
-		t.Error("expected error for invalid JSON")
-	}
+	assert.Error(t, err, "expected error for invalid JSON")
 }

--- a/collector/nvidia_oem_test.go
+++ b/collector/nvidia_oem_test.go
@@ -1,0 +1,405 @@
+package collector
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"log/slog"
+)
+
+// MockClient implements common.Client for testing
+type MockClient struct {
+	responses map[string]string
+}
+
+func NewMockClient(responses map[string]string) *MockClient {
+	return &MockClient{responses: responses}
+}
+
+func (m *MockClient) Get(url string) (*http.Response, error) {
+	body, ok := m.responses[url]
+	if !ok {
+		return &http.Response{
+			StatusCode: 404,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}
+	
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func (m *MockClient) GetWithHeaders(url string, headers map[string]string) (*http.Response, error) {
+	return m.Get(url)
+}
+
+func (m *MockClient) Post(url string, payload interface{}) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *MockClient) PostWithHeaders(url string, payload interface{}, headers map[string]string) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *MockClient) PostWithContentType(url string, contentType string, payload interface{}) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *MockClient) Put(url string, payload interface{}) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *MockClient) PutWithHeaders(url string, payload interface{}, headers map[string]string) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *MockClient) Patch(url string, payload interface{}) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *MockClient) PatchWithHeaders(url string, payload interface{}, headers map[string]string) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *MockClient) Delete(url string) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func (m *MockClient) DeleteWithHeaders(url string, headers map[string]string) (*http.Response, error) {
+	return m.Delete(url)
+}
+
+func (m *MockClient) DeleteWithPayload(url string, payload interface{}) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *MockClient) DeleteWithContentType(url string, contentType string, payload interface{}) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *MockClient) PostMultipart(url string, payload map[string]io.Reader) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *MockClient) PostMultipartWithHeaders(url string, payload map[string]io.Reader, headers map[string]string) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestIsNvidiaGPUMemory(t *testing.T) {
+	tests := []struct {
+		name     string
+		memoryID string
+		expected bool
+	}{
+		{"GPU memory", "GPU_0_DRAM_0", true},
+		{"GPU memory variant", "GPU_1_DRAM_1", true},
+		{"Regular memory", "DIMM_A1", false},
+		{"CPU memory", "CPU_0_DIMM_0", false},
+		{"Empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsNvidiaGPUMemory(tt.memoryID)
+			if result != tt.expected {
+				t.Errorf("IsNvidiaGPUMemory(%s) = %v, expected %v", tt.memoryID, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsNvidiaGPU(t *testing.T) {
+	tests := []struct {
+		name        string
+		processorID string
+		expected    bool
+	}{
+		{"GPU processor", "GPU_0", true},
+		{"GPU processor variant", "GPU_7", true},
+		{"CPU processor", "CPU_0", false},
+		{"Generic processor", "Processor1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsNvidiaGPU(tt.processorID)
+			if result != tt.expected {
+				t.Errorf("IsNvidiaGPU(%s) = %v, expected %v", tt.processorID, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsNVLinkPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		portID   string
+		expected bool
+	}{
+		{"NVLink port", "NVLink_0", true},
+		{"NVLink port high number", "NVLink_17", true},
+		{"PCIe port", "PCIe_0", false},
+		{"Generic port", "Port1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsNVLinkPort(tt.portID)
+			if result != tt.expected {
+				t.Errorf("IsNVLinkPort(%s) = %v, expected %v", tt.portID, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetMemoryOEMMetrics(t *testing.T) {
+	mockResponses := map[string]string{
+		"/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0": `{
+			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0",
+			"Oem": {
+				"Nvidia": {
+					"@odata.type": "#NvidiaMemory.v1_0_0.NvidiaMemory",
+					"RowRemappingFailed": true,
+					"RowRemappingPending": false
+				}
+			}
+		}`,
+		"/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_1_DRAM_0": `{
+			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_1_DRAM_0",
+			"Oem": {}
+		}`,
+	}
+
+	client := NewMockClient(mockResponses)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	helper := NewNvidiaOEMHelper(client, logger)
+
+	t.Run("Memory with Nvidia OEM", func(t *testing.T) {
+		metrics, err := helper.GetMemoryOEMMetrics("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !metrics.RowRemappingFailed {
+			t.Error("expected RowRemappingFailed to be true")
+		}
+		if metrics.RowRemappingPending {
+			t.Error("expected RowRemappingPending to be false")
+		}
+	})
+
+	t.Run("Memory without Nvidia OEM", func(t *testing.T) {
+		metrics, err := helper.GetMemoryOEMMetrics("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_1_DRAM_0")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if metrics.RowRemappingFailed {
+			t.Error("expected RowRemappingFailed to be false (default)")
+		}
+		if metrics.RowRemappingPending {
+			t.Error("expected RowRemappingPending to be false (default)")
+		}
+	})
+}
+
+func TestGetMemoryMetricsOEMData(t *testing.T) {
+	mockResponses := map[string]string{
+		"/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics": `{
+			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics",
+			"Oem": {
+				"Nvidia": {
+					"@odata.type": "#NvidiaMemoryMetrics.v1_2_0.NvidiaGPUMemoryMetrics",
+					"RowRemapping": {
+						"CorrectableRowRemappingCount": 5,
+						"HighAvailabilityBankCount": 5950,
+						"LowAvailabilityBankCount": 1,
+						"MaxAvailabilityBankCount": 5952,
+						"NoAvailabilityBankCount": 1,
+						"PartialAvailabilityBankCount": 0,
+						"UncorrectableRowRemappingCount": 2
+					}
+				}
+			}
+		}`,
+	}
+
+	client := NewMockClient(mockResponses)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	helper := NewNvidiaOEMHelper(client, logger)
+
+	metrics, err := helper.GetMemoryMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if metrics.CorrectableRowRemappingCount != 5 {
+		t.Errorf("expected CorrectableRowRemappingCount = 5, got %d", metrics.CorrectableRowRemappingCount)
+	}
+	if metrics.UncorrectableRowRemappingCount != 2 {
+		t.Errorf("expected UncorrectableRowRemappingCount = 2, got %d", metrics.UncorrectableRowRemappingCount)
+	}
+	if metrics.MaxAvailabilityBankCount != 5952 {
+		t.Errorf("expected MaxAvailabilityBankCount = 5952, got %d", metrics.MaxAvailabilityBankCount)
+	}
+	if metrics.NoAvailabilityBankCount != 1 {
+		t.Errorf("expected NoAvailabilityBankCount = 1, got %d", metrics.NoAvailabilityBankCount)
+	}
+}
+
+func TestGetProcessorMetricsOEMData(t *testing.T) {
+	mockResponses := map[string]string{
+		"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/ProcessorMetrics": `{
+			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/ProcessorMetrics",
+			"Oem": {
+				"Nvidia": {
+					"@odata.type": "#NvidiaProcessorMetrics.v1_4_0.NvidiaGPUProcessorMetrics",
+					"SMUtilizationPercent": 85.5,
+					"SMActivityPercent": 90.2,
+					"TensorCoreActivityPercent": 75.3,
+					"FP32ActivityPercent": 60.0,
+					"SRAMECCErrorThresholdExceeded": true,
+					"NVLinkDataRxBandwidthGbps": 125.5,
+					"NVLinkDataTxBandwidthGbps": 130.2,
+					"PCIeRXBytes": 1000000,
+					"PCIeTXBytes": 2000000,
+					"ThrottleReasons": ["Thermal", "Power"]
+				}
+			}
+		}`,
+	}
+
+	client := NewMockClient(mockResponses)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	helper := NewNvidiaOEMHelper(client, logger)
+
+	metrics, err := helper.GetProcessorMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/ProcessorMetrics")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if metrics.SMUtilizationPercent != 85.5 {
+		t.Errorf("expected SMUtilizationPercent = 85.5, got %f", metrics.SMUtilizationPercent)
+	}
+	if metrics.TensorCoreActivityPercent != 75.3 {
+		t.Errorf("expected TensorCoreActivityPercent = 75.3, got %f", metrics.TensorCoreActivityPercent)
+	}
+	if !metrics.SRAMECCErrorThresholdExceeded {
+		t.Error("expected SRAMECCErrorThresholdExceeded to be true")
+	}
+	if metrics.PCIeRXBytes != 1000000 {
+		t.Errorf("expected PCIeRXBytes = 1000000, got %d", metrics.PCIeRXBytes)
+	}
+	if len(metrics.ThrottleReasons) != 2 || metrics.ThrottleReasons[0] != "Thermal" {
+		t.Errorf("unexpected ThrottleReasons: %v", metrics.ThrottleReasons)
+	}
+}
+
+func TestGetPortMetricsOEMData(t *testing.T) {
+	mockResponses := map[string]string{
+		"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Ports/NVLink_0/Metrics": `{
+			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Ports/NVLink_0/Metrics",
+			"Oem": {
+				"Nvidia": {
+					"@odata.type": "#NvidiaPortMetrics.v1_6_0.NvidiaNVLinkPortMetrics",
+					"NVLinkErrors": {
+						"RuntimeError": true,
+						"TrainingError": false
+					},
+					"LinkErrorRecoveryCount": 10,
+					"LinkDownedCount": 2,
+					"SymbolErrors": 5,
+					"MalformedPackets": 3,
+					"BitErrorRate": 1.5e-10,
+					"EffectiveBER": 1.2e-10
+				}
+			}
+		}`,
+	}
+
+	client := NewMockClient(mockResponses)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	helper := NewNvidiaOEMHelper(client, logger)
+
+	metrics, err := helper.GetPortMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Ports/NVLink_0/Metrics")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !metrics.NVLinkErrorsRuntimeError {
+		t.Error("expected NVLinkErrorsRuntimeError to be true")
+	}
+	if metrics.NVLinkErrorsTrainingError {
+		t.Error("expected NVLinkErrorsTrainingError to be false")
+	}
+	if metrics.LinkErrorRecoveryCount != 10 {
+		t.Errorf("expected LinkErrorRecoveryCount = 10, got %d", metrics.LinkErrorRecoveryCount)
+	}
+	if metrics.SymbolErrors != 5 {
+		t.Errorf("expected SymbolErrors = 5, got %d", metrics.SymbolErrors)
+	}
+	if metrics.BitErrorRate != 1.5e-10 {
+		t.Errorf("expected BitErrorRate = 1.5e-10, got %e", metrics.BitErrorRate)
+	}
+}
+
+func TestHelperFunctions(t *testing.T) {
+	t.Run("getFloat64", func(t *testing.T) {
+		data := map[string]interface{}{
+			"float":   123.45,
+			"int":     100,
+			"int64":   int64(200),
+			"string":  "not a number",
+			"missing": nil,
+		}
+
+		if v := getFloat64(data, "float"); v != 123.45 {
+			t.Errorf("expected 123.45, got %f", v)
+		}
+		if v := getFloat64(data, "int"); v != 100.0 {
+			t.Errorf("expected 100.0, got %f", v)
+		}
+		if v := getFloat64(data, "int64"); v != 200.0 {
+			t.Errorf("expected 200.0, got %f", v)
+		}
+		if v := getFloat64(data, "string"); v != 0.0 {
+			t.Errorf("expected 0.0 for invalid type, got %f", v)
+		}
+		if v := getFloat64(data, "missing"); v != 0.0 {
+			t.Errorf("expected 0.0 for missing key, got %f", v)
+		}
+	})
+
+	t.Run("getInt64", func(t *testing.T) {
+		data := map[string]interface{}{
+			"float":   123.45,
+			"int":     100,
+			"int64":   int64(200),
+			"string":  "not a number",
+			"missing": nil,
+		}
+
+		if v := getInt64(data, "float"); v != 123 {
+			t.Errorf("expected 123, got %d", v)
+		}
+		if v := getInt64(data, "int"); v != 100 {
+			t.Errorf("expected 100, got %d", v)
+		}
+		if v := getInt64(data, "int64"); v != 200 {
+			t.Errorf("expected 200, got %d", v)
+		}
+		if v := getInt64(data, "string"); v != 0 {
+			t.Errorf("expected 0 for invalid type, got %d", v)
+		}
+		if v := getInt64(data, "missing"); v != 0 {
+			t.Errorf("expected 0 for missing key, got %d", v)
+		}
+	})
+}

--- a/collector/nvidia_oem_test.go
+++ b/collector/nvidia_oem_test.go
@@ -7,399 +7,253 @@ import (
 	"testing"
 
 	"log/slog"
+
+	"github.com/stmcginnis/gofish/common"
 )
 
-// MockClient implements common.Client for testing
-type MockClient struct {
-	responses map[string]string
-}
-
-func NewMockClient(responses map[string]string) *MockClient {
-	return &MockClient{responses: responses}
-}
-
-func (m *MockClient) Get(url string) (*http.Response, error) {
-	body, ok := m.responses[url]
-	if !ok {
-		return &http.Response{
-			StatusCode: 404,
-			Body:       io.NopCloser(strings.NewReader("")),
-		}, nil
-	}
-	
-	return &http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(strings.NewReader(body)),
-	}, nil
-}
-
-func (m *MockClient) GetWithHeaders(url string, headers map[string]string) (*http.Response, error) {
-	return m.Get(url)
-}
-
-func (m *MockClient) Post(url string, payload interface{}) (*http.Response, error) {
-	return nil, nil
-}
-
-func (m *MockClient) PostWithHeaders(url string, payload interface{}, headers map[string]string) (*http.Response, error) {
-	return nil, nil
-}
-
-func (m *MockClient) PostWithContentType(url string, contentType string, payload interface{}) (*http.Response, error) {
-	return nil, nil
-}
-
-func (m *MockClient) Put(url string, payload interface{}) (*http.Response, error) {
-	return nil, nil
-}
-
-func (m *MockClient) PutWithHeaders(url string, payload interface{}, headers map[string]string) (*http.Response, error) {
-	return nil, nil
-}
-
-func (m *MockClient) Patch(url string, payload interface{}) (*http.Response, error) {
-	return nil, nil
-}
-
-func (m *MockClient) PatchWithHeaders(url string, payload interface{}, headers map[string]string) (*http.Response, error) {
-	return nil, nil
-}
-
-func (m *MockClient) Delete(url string) (*http.Response, error) {
-	return &http.Response{
-		StatusCode: 200,
-		Body:       io.NopCloser(strings.NewReader("")),
-	}, nil
-}
-
-func (m *MockClient) DeleteWithHeaders(url string, headers map[string]string) (*http.Response, error) {
-	return m.Delete(url)
-}
-
-func (m *MockClient) DeleteWithPayload(url string, payload interface{}) (*http.Response, error) {
-	return nil, nil
-}
-
-func (m *MockClient) DeleteWithContentType(url string, contentType string, payload interface{}) (*http.Response, error) {
-	return nil, nil
-}
-
-func (m *MockClient) PostMultipart(url string, payload map[string]io.Reader) (*http.Response, error) {
-	return nil, nil
-}
-
-func (m *MockClient) PostMultipartWithHeaders(url string, payload map[string]io.Reader, headers map[string]string) (*http.Response, error) {
-	return nil, nil
-}
-
-func TestIsNvidiaGPUMemory(t *testing.T) {
-	tests := []struct {
-		name     string
-		memoryID string
-		expected bool
-	}{
-		{"GPU memory", "GPU_0_DRAM_0", true},
-		{"GPU memory variant", "GPU_1_DRAM_1", true},
-		{"Regular memory", "DIMM_A1", false},
-		{"CPU memory", "CPU_0_DIMM_0", false},
-		{"Empty string", "", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := IsNvidiaGPUMemory(tt.memoryID)
-			if result != tt.expected {
-				t.Errorf("IsNvidiaGPUMemory(%s) = %v, expected %v", tt.memoryID, result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestIsNvidiaGPU(t *testing.T) {
-	tests := []struct {
-		name        string
-		processorID string
-		expected    bool
-	}{
-		{"GPU processor", "GPU_0", true},
-		{"GPU processor variant", "GPU_7", true},
-		{"CPU processor", "CPU_0", false},
-		{"Generic processor", "Processor1", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := IsNvidiaGPU(tt.processorID)
-			if result != tt.expected {
-				t.Errorf("IsNvidiaGPU(%s) = %v, expected %v", tt.processorID, result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestIsNVLinkPort(t *testing.T) {
-	tests := []struct {
-		name     string
-		portID   string
-		expected bool
-	}{
-		{"NVLink port", "NVLink_0", true},
-		{"NVLink port high number", "NVLink_17", true},
-		{"PCIe port", "PCIe_0", false},
-		{"Generic port", "Port1", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := IsNVLinkPort(tt.portID)
-			if result != tt.expected {
-				t.Errorf("IsNVLinkPort(%s) = %v, expected %v", tt.portID, result, tt.expected)
-			}
-		})
-	}
-}
-
 func TestGetMemoryOEMMetrics(t *testing.T) {
-	mockResponses := map[string]string{
-		"/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0": `{
-			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0",
-			"Oem": {
-				"Nvidia": {
-					"@odata.type": "#NvidiaMemory.v1_0_0.NvidiaMemory",
-					"RowRemappingFailed": true,
-					"RowRemappingPending": false
-				}
+	memoryJSON := `{
+		"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0",
+		"Oem": {
+			"Nvidia": {
+				"@odata.type": "#NvidiaMemory.v1_0_0.NvidiaMemory",
+				"RowRemappingFailed": true,
+				"RowRemappingPending": false
 			}
-		}`,
-		"/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_1_DRAM_0": `{
-			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_1_DRAM_0",
-			"Oem": {}
-		}`,
+		}
+	}`
+
+	client := &common.TestClient{}
+	client.CustomReturnForActions = map[string][]interface{}{
+		http.MethodGet: {
+			&http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(memoryJSON)),
+			},
+		},
 	}
 
-	client := NewMockClient(mockResponses)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	helper := NewNvidiaOEMHelper(client, logger)
+	logger := slog.Default()
+	oemClient := NewNvidiaOEMClient(client, logger)
 
-	t.Run("Memory with Nvidia OEM", func(t *testing.T) {
-		metrics, err := helper.GetMemoryOEMMetrics("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+	metrics, err := oemClient.GetMemoryOEMMetrics("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-		if !metrics.RowRemappingFailed {
-			t.Error("expected RowRemappingFailed to be true")
-		}
-		if metrics.RowRemappingPending {
-			t.Error("expected RowRemappingPending to be false")
-		}
-	})
+	if !metrics.RowRemappingFailed {
+		t.Errorf("expected RowRemappingFailed to be true")
+	}
 
-	t.Run("Memory without Nvidia OEM", func(t *testing.T) {
-		metrics, err := helper.GetMemoryOEMMetrics("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_1_DRAM_0")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if metrics.RowRemappingFailed {
-			t.Error("expected RowRemappingFailed to be false (default)")
-		}
-		if metrics.RowRemappingPending {
-			t.Error("expected RowRemappingPending to be false (default)")
-		}
-	})
+	if metrics.RowRemappingPending {
+		t.Errorf("expected RowRemappingPending to be false")
+	}
 }
 
 func TestGetMemoryMetricsOEMData(t *testing.T) {
-	mockResponses := map[string]string{
-		"/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics": `{
-			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics",
-			"Oem": {
-				"Nvidia": {
-					"@odata.type": "#NvidiaMemoryMetrics.v1_2_0.NvidiaGPUMemoryMetrics",
-					"RowRemapping": {
-						"CorrectableRowRemappingCount": 5,
-						"HighAvailabilityBankCount": 5950,
-						"LowAvailabilityBankCount": 1,
-						"MaxAvailabilityBankCount": 5952,
-						"NoAvailabilityBankCount": 1,
-						"PartialAvailabilityBankCount": 0,
-						"UncorrectableRowRemappingCount": 2
-					}
+	metricsJSON := `{
+		"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics",
+		"Oem": {
+			"Nvidia": {
+				"@odata.type": "#NvidiaMemoryMetrics.v1_2_0.NvidiaGPUMemoryMetrics",
+				"RowRemapping": {
+					"CorrectableRowRemappingCount": 5,
+					"HighAvailabilityBankCount": 10,
+					"LowAvailabilityBankCount": 2,
+					"MaxAvailabilityBankCount": 100,
+					"NoAvailabilityBankCount": 0,
+					"PartialAvailabilityBankCount": 3,
+					"UncorrectableRowRemappingCount": 1
 				}
 			}
-		}`,
+		}
+	}`
+
+	client := &common.TestClient{}
+	client.CustomReturnForActions = map[string][]interface{}{
+		http.MethodGet: {
+			&http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(metricsJSON)),
+			},
+		},
 	}
 
-	client := NewMockClient(mockResponses)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	helper := NewNvidiaOEMHelper(client, logger)
+	logger := slog.Default()
+	oemClient := NewNvidiaOEMClient(client, logger)
 
-	metrics, err := helper.GetMemoryMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics")
+	metrics, err := oemClient.GetMemoryMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if metrics.CorrectableRowRemappingCount != 5 {
-		t.Errorf("expected CorrectableRowRemappingCount = 5, got %d", metrics.CorrectableRowRemappingCount)
+		t.Errorf("expected CorrectableRowRemappingCount to be 5, got %d", metrics.CorrectableRowRemappingCount)
 	}
-	if metrics.UncorrectableRowRemappingCount != 2 {
-		t.Errorf("expected UncorrectableRowRemappingCount = 2, got %d", metrics.UncorrectableRowRemappingCount)
-	}
-	if metrics.MaxAvailabilityBankCount != 5952 {
-		t.Errorf("expected MaxAvailabilityBankCount = 5952, got %d", metrics.MaxAvailabilityBankCount)
-	}
-	if metrics.NoAvailabilityBankCount != 1 {
-		t.Errorf("expected NoAvailabilityBankCount = 1, got %d", metrics.NoAvailabilityBankCount)
+
+	if metrics.UncorrectableRowRemappingCount != 1 {
+		t.Errorf("expected UncorrectableRowRemappingCount to be 1, got %d", metrics.UncorrectableRowRemappingCount)
 	}
 }
 
 func TestGetProcessorMetricsOEMData(t *testing.T) {
-	mockResponses := map[string]string{
-		"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/ProcessorMetrics": `{
-			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/ProcessorMetrics",
-			"Oem": {
-				"Nvidia": {
-					"@odata.type": "#NvidiaProcessorMetrics.v1_4_0.NvidiaGPUProcessorMetrics",
-					"SMUtilizationPercent": 85.5,
-					"SMActivityPercent": 90.2,
-					"TensorCoreActivityPercent": 75.3,
-					"FP32ActivityPercent": 60.0,
-					"SRAMECCErrorThresholdExceeded": true,
-					"NVLinkDataRxBandwidthGbps": 125.5,
-					"NVLinkDataTxBandwidthGbps": 130.2,
-					"PCIeRXBytes": 1000000,
-					"PCIeTXBytes": 2000000,
-					"ThrottleReasons": ["Thermal", "Power"]
-				}
+	metricsJSON := `{
+		"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/ProcessorMetrics",
+		"Oem": {
+			"Nvidia": {
+				"@odata.type": "#NvidiaProcessorMetrics.v1_0_0.NvidiaProcessorMetrics",
+				"SMUtilizationPercent": 75.5,
+				"SMActivityPercent": 80.2,
+				"SMOccupancyPercent": 65.0,
+				"TensorCoreActivityPercent": 45.5,
+				"FP16ActivityPercent": 30.0,
+				"FP32ActivityPercent": 25.5,
+				"FP64ActivityPercent": 10.0,
+				"IntegerActivityUtilizationPercent": 15.5,
+				"SRAMECCErrorThresholdExceeded": true,
+				"NVLinkDataRxBandwidthGbps": 100.5,
+				"NVLinkDataTxBandwidthGbps": 95.3,
+				"PCIeRXBytes": 1024000,
+				"PCIeTXBytes": 2048000,
+				"ThrottleReasons": ["ThermalLimit", "PowerLimit"]
 			}
-		}`,
+		}
+	}`
+
+	client := &common.TestClient{}
+	client.CustomReturnForActions = map[string][]interface{}{
+		http.MethodGet: {
+			&http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(metricsJSON)),
+			},
+		},
 	}
 
-	client := NewMockClient(mockResponses)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	helper := NewNvidiaOEMHelper(client, logger)
+	logger := slog.Default()
+	oemClient := NewNvidiaOEMClient(client, logger)
 
-	metrics, err := helper.GetProcessorMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/ProcessorMetrics")
+	metrics, err := oemClient.GetProcessorMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/ProcessorMetrics")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if metrics.SMUtilizationPercent != 85.5 {
-		t.Errorf("expected SMUtilizationPercent = 85.5, got %f", metrics.SMUtilizationPercent)
+	if metrics.SMUtilizationPercent != 75.5 {
+		t.Errorf("expected SMUtilizationPercent to be 75.5, got %f", metrics.SMUtilizationPercent)
 	}
-	if metrics.TensorCoreActivityPercent != 75.3 {
-		t.Errorf("expected TensorCoreActivityPercent = 75.3, got %f", metrics.TensorCoreActivityPercent)
-	}
+
 	if !metrics.SRAMECCErrorThresholdExceeded {
-		t.Error("expected SRAMECCErrorThresholdExceeded to be true")
+		t.Errorf("expected SRAMECCErrorThresholdExceeded to be true")
 	}
-	if metrics.PCIeRXBytes != 1000000 {
-		t.Errorf("expected PCIeRXBytes = 1000000, got %d", metrics.PCIeRXBytes)
-	}
-	if len(metrics.ThrottleReasons) != 2 || metrics.ThrottleReasons[0] != "Thermal" {
-		t.Errorf("unexpected ThrottleReasons: %v", metrics.ThrottleReasons)
+
+	if len(metrics.ThrottleReasons) != 2 {
+		t.Errorf("expected 2 throttle reasons, got %d", len(metrics.ThrottleReasons))
 	}
 }
 
 func TestGetPortMetricsOEMData(t *testing.T) {
-	mockResponses := map[string]string{
-		"/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Ports/NVLink_0/Metrics": `{
-			"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Ports/NVLink_0/Metrics",
-			"Oem": {
-				"Nvidia": {
-					"@odata.type": "#NvidiaPortMetrics.v1_6_0.NvidiaNVLinkPortMetrics",
-					"NVLinkErrors": {
-						"RuntimeError": true,
-						"TrainingError": false
-					},
-					"LinkErrorRecoveryCount": 10,
-					"LinkDownedCount": 2,
-					"SymbolErrors": 5,
-					"MalformedPackets": 3,
-					"BitErrorRate": 1.5e-10,
-					"EffectiveBER": 1.2e-10
-				}
+	metricsJSON := `{
+		"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Ports/NVLink_0/Metrics",
+		"Oem": {
+			"Nvidia": {
+				"@odata.type": "#NvidiaPortMetrics.v1_0_0.NvidiaPortMetrics",
+				"NVLinkErrors": {
+					"RuntimeError": true,
+					"TrainingError": false
+				},
+				"LinkErrorRecoveryCount": 10,
+				"LinkDownedCount": 2,
+				"SymbolErrors": 100,
+				"MalformedPackets": 5,
+				"BitErrorRate": 0.001,
+				"EffectiveBER": 0.0005
 			}
-		}`,
+		}
+	}`
+
+	client := &common.TestClient{}
+	client.CustomReturnForActions = map[string][]interface{}{
+		http.MethodGet: {
+			&http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(metricsJSON)),
+			},
+		},
 	}
 
-	client := NewMockClient(mockResponses)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	helper := NewNvidiaOEMHelper(client, logger)
+	logger := slog.Default()
+	oemClient := NewNvidiaOEMClient(client, logger)
 
-	metrics, err := helper.GetPortMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Ports/NVLink_0/Metrics")
+	metrics, err := oemClient.GetPortMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Ports/NVLink_0/Metrics")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if !metrics.NVLinkErrorsRuntimeError {
-		t.Error("expected NVLinkErrorsRuntimeError to be true")
+		t.Errorf("expected NVLinkErrorsRuntimeError to be true")
 	}
+
 	if metrics.NVLinkErrorsTrainingError {
-		t.Error("expected NVLinkErrorsTrainingError to be false")
+		t.Errorf("expected NVLinkErrorsTrainingError to be false")
 	}
+
 	if metrics.LinkErrorRecoveryCount != 10 {
-		t.Errorf("expected LinkErrorRecoveryCount = 10, got %d", metrics.LinkErrorRecoveryCount)
-	}
-	if metrics.SymbolErrors != 5 {
-		t.Errorf("expected SymbolErrors = 5, got %d", metrics.SymbolErrors)
-	}
-	if metrics.BitErrorRate != 1.5e-10 {
-		t.Errorf("expected BitErrorRate = 1.5e-10, got %e", metrics.BitErrorRate)
+		t.Errorf("expected LinkErrorRecoveryCount to be 10, got %d", metrics.LinkErrorRecoveryCount)
 	}
 }
 
-func TestHelperFunctions(t *testing.T) {
-	t.Run("getFloat64", func(t *testing.T) {
-		data := map[string]interface{}{
-			"float":   123.45,
-			"int":     100,
-			"int64":   int64(200),
-			"string":  "not a number",
-			"missing": nil,
-		}
 
-		if v := getFloat64(data, "float"); v != 123.45 {
-			t.Errorf("expected 123.45, got %f", v)
-		}
-		if v := getFloat64(data, "int"); v != 100.0 {
-			t.Errorf("expected 100.0, got %f", v)
-		}
-		if v := getFloat64(data, "int64"); v != 200.0 {
-			t.Errorf("expected 200.0, got %f", v)
-		}
-		if v := getFloat64(data, "string"); v != 0.0 {
-			t.Errorf("expected 0.0 for invalid type, got %f", v)
-		}
-		if v := getFloat64(data, "missing"); v != 0.0 {
-			t.Errorf("expected 0.0 for missing key, got %f", v)
-		}
-	})
+func TestGetMemoryOEMMetrics_EmptyOem(t *testing.T) {
+	memoryJSON := `{
+		"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0",
+		"Oem": {}
+	}`
 
-	t.Run("getInt64", func(t *testing.T) {
-		data := map[string]interface{}{
-			"float":   123.45,
-			"int":     100,
-			"int64":   int64(200),
-			"string":  "not a number",
-			"missing": nil,
-		}
+	client := &common.TestClient{}
+	client.CustomReturnForActions = map[string][]interface{}{
+		http.MethodGet: {
+			&http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(memoryJSON)),
+			},
+		},
+	}
 
-		if v := getInt64(data, "float"); v != 123 {
-			t.Errorf("expected 123, got %d", v)
-		}
-		if v := getInt64(data, "int"); v != 100 {
-			t.Errorf("expected 100, got %d", v)
-		}
-		if v := getInt64(data, "int64"); v != 200 {
-			t.Errorf("expected 200, got %d", v)
-		}
-		if v := getInt64(data, "string"); v != 0 {
-			t.Errorf("expected 0 for invalid type, got %d", v)
-		}
-		if v := getInt64(data, "missing"); v != 0 {
-			t.Errorf("expected 0 for missing key, got %d", v)
-		}
-	})
+	logger := slog.Default()
+	oemClient := NewNvidiaOEMClient(client, logger)
+
+	metrics, err := oemClient.GetMemoryOEMMetrics("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should return zero values when OEM data is missing
+	if metrics.RowRemappingFailed {
+		t.Errorf("expected RowRemappingFailed to be false for empty OEM")
+	}
+
+	if metrics.RowRemappingPending {
+		t.Errorf("expected RowRemappingPending to be false for empty OEM")
+	}
+}
+
+func TestGetMemoryOEMMetrics_ErrorHandling(t *testing.T) {
+	// Test with invalid JSON
+	client := &common.TestClient{}
+	client.CustomReturnForActions = map[string][]interface{}{
+		http.MethodGet: {
+			&http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader("invalid json")),
+			},
+		},
+	}
+
+	logger := slog.Default()
+	oemClient := NewNvidiaOEMClient(client, logger)
+
+	_, err := oemClient.GetMemoryOEMMetrics("/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0")
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
 }

--- a/collector/nvidia_oem_test.go
+++ b/collector/nvidia_oem_test.go
@@ -165,8 +165,8 @@ func TestGetPortMetricsOEMData(t *testing.T) {
 	metrics, err := oemClient.GetPortMetricsOEMData("/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Ports/NVLink_0/Metrics")
 	require.NoError(t, err)
 
-	assert.True(t, metrics.NVLinkErrorsRuntimeError, "expected NVLinkErrorsRuntimeError to be true")
-	assert.False(t, metrics.NVLinkErrorsTrainingError, "expected NVLinkErrorsTrainingError to be false")
+	assert.True(t, metrics.NVLinkErrors.RuntimeError, "expected NVLinkErrors.RuntimeError to be true")
+	assert.False(t, metrics.NVLinkErrors.TrainingError, "expected NVLinkErrors.TrainingError to be false")
 	assert.Equal(t, int64(10), metrics.LinkErrorRecoveryCount, "expected LinkErrorRecoveryCount to be 10")
 }
 

--- a/collector/system_collector.go
+++ b/collector/system_collector.go
@@ -56,6 +56,7 @@ func createSystemMetricMap() map[string]Metric {
 	addToMetricMap(systemMetrics, SystemSubsystem, "memory_state", fmt.Sprintf("system memory state,%s", CommonStateHelp), SystemMemoryLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "memory_health_state", fmt.Sprintf("system memory health state,%s", CommonHealthHelp), SystemMemoryLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "memory_capacity", "system memory capacity, MiB", SystemMemoryLabelNames)
+	
 
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_state", fmt.Sprintf("system processor state,%s", CommonStateHelp), SystemProcessorLabelNames)
 	addToMetricMap(systemMetrics, SystemSubsystem, "processor_health_state", fmt.Sprintf("system processor health state,%s", CommonHealthHelp), SystemProcessorLabelNames)
@@ -206,7 +207,7 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) { //nolint:gocycl
 			} else {
 				wg1.Add(len(memories))
 				for _, memory := range memories {
-					go parseMemory(ch, systemHostName, memory, wg1)
+					go parseMemory(ch, systemHostName, memory, wg1, systemLogger)
 				}
 			}
 
@@ -340,7 +341,7 @@ func (s *SystemCollector) Collect(ch chan<- prometheus.Metric) { //nolint:gocycl
 	}
 }
 
-func parseMemory(ch chan<- prometheus.Metric, systemHostName string, memory *redfish.Memory, wg *sync.WaitGroup) {
+func parseMemory(ch chan<- prometheus.Metric, systemHostName string, memory *redfish.Memory, wg *sync.WaitGroup, logger *slog.Logger) {
 	defer wg.Done()
 	memoryName := memory.Name
 	memoryID := memory.ID

--- a/collector/testdata/nvidia_gpu_memory.json
+++ b/collector/testdata/nvidia_gpu_memory.json
@@ -1,0 +1,41 @@
+{
+  "@odata.type": "#Memory.v1_17_0.Memory",
+  "@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0",
+  "Id": "GPU_0_DRAM_0",
+  "Name": "GPU_0_DRAM_0",
+  "MemoryDeviceType": "HBM3",
+  "MemoryType": "HBM3",
+  "MemoryMedia": [
+    "DRAM"
+  ],
+  "CapacityMiB": 98304,
+  "DataWidthBits": 8192,
+  "BusWidthBits": 8192,
+  "Manufacturer": "NVIDIA",
+  "SerialNumber": "1628822001937",
+  "PartNumber": "699-2H500-0207-000",
+  "AllowedSpeedsMHz": [
+    3200
+  ],
+  "OperatingSpeedMhz": 3200,
+  "MemoryLocation": {
+    "Socket": 0,
+    "MemoryController": 0,
+    "Channel": 0,
+    "Slot": 0
+  },
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "Metrics": {
+    "@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics"
+  },
+  "Oem": {
+    "Nvidia": {
+      "@odata.type": "#NvidiaMemory.v1_0_0.NvidiaMemory",
+      "RowRemappingFailed": false,
+      "RowRemappingPending": false
+    }
+  }
+}

--- a/collector/testdata/nvidia_gpu_memory_metrics.json
+++ b/collector/testdata/nvidia_gpu_memory_metrics.json
@@ -1,0 +1,40 @@
+{
+  "@odata.type": "#MemoryMetrics.v1_6_1.MemoryMetrics",
+  "@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Memory/GPU_0_DRAM_0/MemoryMetrics",
+  "Id": "MemoryMetrics",
+  "Name": "Memory Metrics",
+  "BlockSizeBytes": 4096,
+  "CurrentPeriod": {
+    "CorrectableECCErrorCount": 0,
+    "UncorrectableECCErrorCount": 0
+  },
+  "LifeTime": {
+    "CorrectableECCErrorCount": 0,
+    "UncorrectableECCErrorCount": 0
+  },
+  "HealthData": {
+    "AlarmTrips": {
+      "Temperature": false,
+      "SpareBlock": false,
+      "UncorrectableECCError": false,
+      "CorrectableECCError": false
+    },
+    "DataLossDetected": false,
+    "PerformanceDegraded": false,
+    "PredictedMediaLifeLeftPercent": 100
+  },
+  "Oem": {
+    "Nvidia": {
+      "@odata.type": "#NvidiaMemoryMetrics.v1_2_0.NvidiaGPUMemoryMetrics",
+      "RowRemapping": {
+        "CorrectableRowRemappingCount": 0,
+        "HighAvailabilityBankCount": 0,
+        "LowAvailabilityBankCount": 0,
+        "MaxAvailabilityBankCount": 5952,
+        "NoAvailabilityBankCount": 0,
+        "PartialAvailabilityBankCount": 0,
+        "UncorrectableRowRemappingCount": 0
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds dedicated GPU collector to export Nvidia-specific OEM metrics from Redfish API.

**Changes**
- Created gpu_collector.go to collect GPU-specific metrics (memory, processor, NVLink ports)
- Added nvidia_oem.go helper for extracting Nvidia OEM fields from Redfish JSON responses
- Integrated GPU collector into redfish_collector.go
- Removed GPU-specific logic from system_collector.go for better separation of concerns

**Metrics Added**
GPU Memory OEM Metrics:
- Row remapping status (failed/pending)
- Correctable/uncorrectable row remapping counts
- Memory bank availability counts (high/low/max/no/partial)

GPU Processor OEM Metrics (structure ready):
- SM utilization/activity/occupancy percentages
- Tensor core and FP16/32/64 activity percentages
- PCIe bandwidth metrics
- SRAM ECC error threshold status

NVLink Port OEM Metrics (structure ready):
- Runtime/training error status
- Link error recovery and downed counts
- Symbol errors and bit error rates

**Testing**
- Comprehensive unit tests for GPU memory metrics collection
- Test fixtures for Nvidia OEM JSON responses
- All tests passing, linter clean

```
# HELP redfish_gpu_memory_correctable_row_remapping_count GPU memory correctable row remapping count
# TYPE redfish_gpu_memory_correctable_row_remapping_count gauge
redfish_gpu_memory_correctable_row_remapping_count{gpu_id="GPU_0",hostname="HGX_Baseboard_0",memory_id="GPU_0_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_correctable_row_remapping_count{gpu_id="GPU_1",hostname="HGX_Baseboard_0",memory_id="GPU_1_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_correctable_row_remapping_count{gpu_id="GPU_2",hostname="HGX_Baseboard_0",memory_id="GPU_2_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_correctable_row_remapping_count{gpu_id="GPU_3",hostname="HGX_Baseboard_0",memory_id="GPU_3_DRAM_0",system_id="HGX_Baseboard_0"} 0
```

```
# HELP redfish_gpu_memory_row_remapping_pending GPU memory row remapping pending status (1 if pending)
# TYPE redfish_gpu_memory_row_remapping_pending gauge
redfish_gpu_memory_row_remapping_pending{gpu_id="GPU_0",hostname="HGX_Baseboard_0",memory_id="GPU_0_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_row_remapping_pending{gpu_id="GPU_1",hostname="HGX_Baseboard_0",memory_id="GPU_1_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_row_remapping_pending{gpu_id="GPU_2",hostname="HGX_Baseboard_0",memory_id="GPU_2_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_row_remapping_pending{gpu_id="GPU_3",hostname="HGX_Baseboard_0",memory_id="GPU_3_DRAM_0",system_id="HGX_Baseboard_0"} 0
```

```
# HELP redfish_gpu_memory_uncorrectable_row_remapping_count GPU memory uncorrectable row remapping count
# TYPE redfish_gpu_memory_uncorrectable_row_remapping_count gauge
redfish_gpu_memory_uncorrectable_row_remapping_count{gpu_id="GPU_0",hostname="HGX_Baseboard_0",memory_id="GPU_0_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_uncorrectable_row_remapping_count{gpu_id="GPU_1",hostname="HGX_Baseboard_0",memory_id="GPU_1_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_uncorrectable_row_remapping_count{gpu_id="GPU_2",hostname="HGX_Baseboard_0",memory_id="GPU_2_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_uncorrectable_row_remapping_count{gpu_id="GPU_3",hostname="HGX_Baseboard_0",memory_id="GPU_3_DRAM_0",system_id="HGX_Baseboard_0"} 0
```

```
# HELP redfish_gpu_memory_correctable_row_remapping_count GPU memory correctable row remapping count
# TYPE redfish_gpu_memory_correctable_row_remapping_count gauge
redfish_gpu_memory_correctable_row_remapping_count{gpu_id="GPU_0",hostname="HGX_Baseboard_0",memory_id="GPU_0_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_correctable_row_remapping_count{gpu_id="GPU_1",hostname="HGX_Baseboard_0",memory_id="GPU_1_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_correctable_row_remapping_count{gpu_id="GPU_2",hostname="HGX_Baseboard_0",memory_id="GPU_2_DRAM_0",system_id="HGX_Baseboard_0"} 0
redfish_gpu_memory_correctable_row_remapping_count{gpu_id="GPU_3",hostname="HGX_Baseboard_0",memory_id="GPU_3_DRAM_0",system_id="HGX_Baseboard_0"} 0
```
