### PR TITLE
chassis_collector: Leak Detection health metric

### DIFF
--- a/collector/chassis_collector_test.go
+++ b/collector/chassis_collector_test.go
@@ -1,0 +1,128 @@
+package collector
+
+import (
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stmcginnis/gofish"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetLeakDetectors(t *testing.T) {
+	tT := map[string]struct {
+		mockSetupFn func() (*testRedfishServer, *gofish.APIClient)
+		expectedLDs int
+	}{
+		"happy path - data was returned in a gofish-expected manner": {
+			mockSetupFn: func() (*testRedfishServer, *gofish.APIClient) {
+				server := newTestRedfishServer(t)
+				server.addRouteFromFixture("/redfish/v1/Chassis", "chassis_collection.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0", "chassis_main.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem", "thermal_subsystem.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection", "leak_detection.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors", "leak_detectors_collection.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_0_ColdPlate", "leak_detector_ok.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_0_Manifold", "leak_detector_ok.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_1_ColdPlate", "leak_detector_ok.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_1_Manifold", "leak_detector_leak.json")
+
+				client := connectToTestServer(t, server)
+
+				return server, client
+			},
+			expectedLDs: 4,
+		},
+		"happy path - OEM returned single LeakDetection in ThermalSubsystem": {
+			mockSetupFn: func() (*testRedfishServer, *gofish.APIClient) {
+				server := newTestRedfishServer(t)
+				server.addRouteFromFixture("/redfish/v1/Chassis", "chassis_collection.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0", "chassis_main.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem", "thermal_subsystem.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection", "single_leak_detection.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors", "leak_detectors_collection.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_0_ColdPlate", "leak_detector_ok.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_0_Manifold", "leak_detector_ok.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_1_ColdPlate", "leak_detector_ok.json")
+				server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_1_Manifold", "leak_detector_leak.json")
+
+				client := connectToTestServer(t, server)
+
+				return server, client
+			},
+			expectedLDs: 4,
+		},
+	}
+
+	for tName, test := range tT {
+		t.Run(tName, func(t *testing.T) {
+			srv, client := test.mockSetupFn()
+			require.NotNil(t, srv)
+			require.NotNil(t, client)
+			t.Cleanup(func() {
+				client.Logout()
+				srv.Close()
+			})
+
+			service := client.GetService()
+			chassis, err := service.Chassis()
+			require.NoError(t, err)
+			require.NotEmpty(t, chassis, "Expected at least one chassis")
+
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			collector := NewChassisCollector(client, logger)
+			thermalSubsystem, err := chassis[0].ThermalSubsystem()
+			require.NoError(t, err)
+
+			detectors := collector.getLeakDetectors(thermalSubsystem, logger)
+
+			require.Equal(t, test.expectedLDs, len(detectors))
+		})
+	}
+}
+
+func TestParseLeakDetector(t *testing.T) {
+	server := newTestRedfishServer(t)
+	server.addRouteFromFixture("/redfish/v1/Chassis", "chassis_collection.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0", "chassis_main.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem", "thermal_subsystem.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection", "single_leak_detection.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors", "leak_detectors_single.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_0_ColdPlate", "leak_detector_ok.json")
+
+	client := connectToTestServer(t, server)
+	t.Cleanup(func() {
+		client.Logout()
+		server.Close()
+	})
+
+	service := client.GetService()
+	chassis, err := service.Chassis()
+	require.NoError(t, err)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	collector := NewChassisCollector(client, logger)
+	thermalSubsystem, err := chassis[0].ThermalSubsystem()
+	require.NoError(t, err)
+
+	detectors := collector.getLeakDetectors(thermalSubsystem, logger)
+	require.Greater(t, len(detectors), 0)
+
+	metricsCh := make(chan prometheus.Metric, 10)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	parseLeakDetector(metricsCh, "test_chassis", detectors[0], wg)
+	close(metricsCh)
+	wg.Wait()
+
+	expected := `label:{name:"chassis_id" value:"test_chassis"} label:{name:"leak_detection_id" value:"LeakDetection"} label:{name:"leak_detector_id" value:"Chassis_0_LeakDetector_0_ColdPlate"} label:{name:"resource" value:"leak_detector"} gauge:{value:1}`
+	for metric := range metricsCh {
+		dto := &dto.Metric{}
+		require.NoError(t, metric.Write(dto))
+		require.Equal(t, expected, dto.String())
+	}
+}

--- a/collector/testdata/chassis_collection.json
+++ b/collector/testdata/chassis_collection.json
@@ -1,0 +1,11 @@
+{
+  "@odata.id": "/redfish/v1/Chassis",
+  "@odata.type": "#ChassisCollection.ChassisCollection",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/Chassis_0"
+    }
+  ],
+  "Members@odata.count": 1,
+  "Name": "Chassis Collection"
+}

--- a/collector/testdata/chassis_main.json
+++ b/collector/testdata/chassis_main.json
@@ -1,0 +1,37 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/Chassis_0",
+  "@odata.type": "#Chassis.v1_22_0.Chassis",
+  "Id": "Chassis_0",
+  "Name": "Chassis_0",
+  "ChassisType": "Shelf",
+  "Manufacturer": "Supermicro",
+  "Model": "GB200 NVL",
+  "SerialNumber": "Foo",
+  "PartNumber": "Foo-Part-Number",
+  "AssetTag": "$PRODUCT_ASSET_TAG",
+  "IndicatorLED": "Off",
+  "PowerState": "On",
+  "Status": {
+    "Health": "OK",
+    "HealthRollup": "OK",
+    "State": "Enabled"
+  },
+  "ThermalSubsystem": {
+    "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem"
+  },
+  "PowerSubsystem": {
+    "@odata.id": "/redfish/v1/Chassis/Chassis_0/PowerSubsystem"
+  },
+  "Links": {
+    "ComputerSystems": [
+      {
+        "@odata.id": "/redfish/v1/Systems/System_0"
+      }
+    ],
+    "ManagedBy": [
+      {
+        "@odata.id": "/redfish/v1/Managers/BMC_0"
+      }
+    ]
+  }
+}

--- a/collector/testdata/leak_detection.json
+++ b/collector/testdata/leak_detection.json
@@ -1,0 +1,14 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection",
+  "@odata.type": "#LeakDetection.v1_0_0.LeakDetection",
+  "Id": "LeakDetection",
+  "Name": "Leak Detection Systems",
+  "Status": {
+    "Health": "OK",
+    "HealthRollup": "OK",
+    "State": "Enabled"
+  },
+  "LeakDetectors": {
+    "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors"
+  }
+}

--- a/collector/testdata/leak_detector_leak.json
+++ b/collector/testdata/leak_detector_leak.json
@@ -1,0 +1,12 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_1_Manifold",
+  "@odata.type": "#LeakDetector.v1_1_0.LeakDetector",
+  "Id": "Chassis_0_LeakDetector_1_Manifold",
+  "Name": "Chassis 0 LeakDetector 1 Manifold",
+  "LeakDetectorType": "Moisture",
+  "DetectorState": "LeakDetected",
+  "Status": {
+    "Health": "Critical",
+    "State": "Enabled"
+  }
+}

--- a/collector/testdata/leak_detector_ok.json
+++ b/collector/testdata/leak_detector_ok.json
@@ -1,0 +1,12 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_0_ColdPlate",
+  "@odata.type": "#LeakDetector.v1_1_0.LeakDetector",
+  "Id": "Chassis_0_LeakDetector_0_ColdPlate",
+  "Name": "Chassis 0 LeakDetector 0 ColdPlate",
+  "LeakDetectorType": "Moisture",
+  "DetectorState": "OK",
+  "Status": {
+    "Health": "OK",
+    "State": "Enabled"
+  }
+}

--- a/collector/testdata/leak_detectors_collection.json
+++ b/collector/testdata/leak_detectors_collection.json
@@ -1,0 +1,21 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors",
+  "@odata.type": "#LeakDetectorCollection.LeakDetectorCollection",
+  "Description": "Collection of Leak Detectors for Chassis Chassis_0",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_0_ColdPlate"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_0_Manifold"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_1_ColdPlate"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_1_Manifold"
+    }
+  ],
+  "Members@odata.count": 4,
+  "Name": "Leak Detector Collection"
+}

--- a/collector/testdata/leak_detectors_single.json
+++ b/collector/testdata/leak_detectors_single.json
@@ -1,0 +1,12 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors",
+  "@odata.type": "#LeakDetectorCollection.LeakDetectorCollection",
+  "Description": "Collection of Leak Detectors for Chassis Chassis_0",
+  "Members": [
+    {
+        "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/Chassis_0_LeakDetector_0_ColdPlate"
+    }
+  ],
+  "Members@odata.count": 1,
+  "Name": "Leak Detector Collection"
+}

--- a/collector/testdata/service_root.json
+++ b/collector/testdata/service_root.json
@@ -6,5 +6,8 @@
   "RedfishVersion": "1.15.0",
   "Systems": {
     "@odata.id": "/redfish/v1/Systems"
+  },
+  "Chassis": {
+    "@odata.id": "/redfish/v1/Chassis"
   }
 }

--- a/collector/testdata/single_leak_detection.json
+++ b/collector/testdata/single_leak_detection.json
@@ -1,0 +1,14 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection",
+  "@odata.type": "#LeakDetection.v1_0_0.LeakDetection",
+  "Id": "LeakDetection",
+  "Name": "Single Leak Detection Object",
+  "Status": {
+    "Health": "OK",
+    "HealthRollup": "OK",
+    "State": "Enabled"
+  },
+  "LeakDetectors": {
+    "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors"
+  }
+}

--- a/collector/testdata/thermal_subsystem.json
+++ b/collector/testdata/thermal_subsystem.json
@@ -1,0 +1,20 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem",
+  "@odata.type": "#ThermalSubsystem.v1_3_0.ThermalSubsystem",
+  "Id": "ThermalSubsystem",
+  "Name": "Thermal Subsystem",
+  "Status": {
+    "Health": "OK",
+    "HealthRollup": "OK",
+    "State": "Enabled"
+  },
+  "LeakDetection": {
+    "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection"
+  },
+  "Fans": {
+    "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/Fans"
+  },
+  "ThermalMetrics": {
+    "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/ThermalMetrics"
+  }
+}

--- a/collector/testdata/thermal_subsystem_buggy.json
+++ b/collector/testdata/thermal_subsystem_buggy.json
@@ -1,0 +1,14 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/Chassis_BuggyOEM/ThermalSubsystem",
+  "@odata.type": "#ThermalSubsystem.v1_3_0.ThermalSubsystem",
+  "Id": "ThermalSubsystem",
+  "Name": "Buggy OEM Thermal Subsystem",
+  "Status": {
+    "Health": "OK",
+    "HealthRollup": "OK",
+    "State": "Enabled"
+  },
+  "LeakDetection": {
+    "@odata.id": "/redfish/v1/Chassis/Chassis_BuggyOEM/ThermalSubsystem/LeakDetection"
+  }
+}

--- a/collector/testdata/thermal_subsystem_buggy_oem.json
+++ b/collector/testdata/thermal_subsystem_buggy_oem.json
@@ -1,0 +1,14 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem",
+  "@odata.type": "#ThermalSubsystem.v1_3_0.ThermalSubsystem",
+  "Id": "ThermalSubsystem",
+  "Name": "Thermal Subsystem (Buggy OEM)",
+  "Status": {
+    "Health": "OK",
+    "HealthRollup": "OK",
+    "State": "Enabled"
+  },
+  "LeakDetection": {
+    "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection"
+  }
+}


### PR DESCRIPTION
Adds leak detector health.

In our very limited slice of hardware where this is available, we discovered a Redfish response which is at odds with what gofish expects of a thermal subsystem leak detection.

So works around that with a sort of 'fallback' behavior which teases out leak detectors in the absence of a fully-compliant Redfish LeakDetection collection.

When pointed at said hardware, seems to do what we'd expect:

```
# HELP redfish_chassis_leak_detector_health chassis leak detector health state,1(OK),2(Warning),3(Critical)
# TYPE redfish_chassis_leak_detector_health gauge
redfish_chassis_leak_detector_health{chassis_id="Chassis_0",leak_detection_id="LeakDetection",leak_detector_id="Chassis_0_LeakDetector_0_ColdPlate",resource="leak_detector"} 1
redfish_chassis_leak_detector_health{chassis_id="Chassis_0",leak_detection_id="LeakDetection",leak_detector_id="Chassis_0_LeakDetector_0_Manifold",resource="leak_detector"} 1
redfish_chassis_leak_detector_health{chassis_id="Chassis_0",leak_detection_id="LeakDetection",leak_detector_id="Chassis_0_LeakDetector_1_ColdPlate",resource="leak_detector"} 1
redfish_chassis_leak_detector_health{chassis_id="Chassis_0",leak_detection_id="LeakDetection",leak_detector_id="Chassis_0_LeakDetector_1_Manifold",resource="leak_detector"} 1
```