### PR TITLE
added tlimit metric for gpus

### DIFF
--- a/collector/gpu_collector_test.go
+++ b/collector/gpu_collector_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -40,7 +41,8 @@ func setupTestServerWithGPU(t *testing.T) *testRedfishServer {
 	
 	setupGPUSystem(server)
 	setupGPUMemory(server)
-	
+	setupGPUProcessorsAndSensors(server)
+
 	return server
 }
 
@@ -122,8 +124,85 @@ func setupGPUMemory(server *testRedfishServer) {
 	})
 }
 
-// TODO: Add these setup functions when processor and NVLink collection is fully implemented
-// setupGPUProcessors and setupNVLinkPorts are commented out until needed
+// testGPUConfig holds configuration for a test GPU
+type testGPUConfig struct {
+	ID          string
+	Name        string
+	Temperature float64
+}
+
+// createGPUProcessor creates a GPU processor response with common fields
+func createGPUProcessor(systemID, gpuID, gpuName string) map[string]interface{} {
+	return map[string]interface{}{
+		"@odata.type":   "#Processor.v1_20_0.Processor",
+		"@odata.id":     fmt.Sprintf("/redfish/v1/Systems/%s/Processors/%s", systemID, gpuID),
+		"Id":            gpuID,
+		"Name":          gpuName,
+		"ProcessorType": "GPU",
+		"Manufacturer":  "NVIDIA",
+		"Model":         "H100",
+		"Status": map[string]string{
+			"State":  "Enabled",
+			"Health": "OK",
+		},
+	}
+}
+
+// createTemperatureSensor creates a temperature sensor response
+func createTemperatureSensor(chassisID, sensorID string, temperature float64) map[string]interface{} {
+	return map[string]interface{}{
+		"@odata.id":    fmt.Sprintf("/redfish/v1/Chassis/%s/Sensors/%s", chassisID, sensorID),
+		"@odata.type":  "#Sensor.v1_7_0.Sensor",
+		"Id":           sensorID,
+		"Name":         fmt.Sprintf("%s Temperature Sensor", chassisID),
+		"Reading":      temperature,
+		"ReadingType":  "Temperature",
+		"ReadingUnits": "Cel",
+		"Status": map[string]interface{}{
+			"State":  "Enabled",
+			"Health": "OK",
+		},
+	}
+}
+
+// setupGPUProcessorsAndSensors adds GPU processors and temperature sensors
+func setupGPUProcessorsAndSensors(server *testRedfishServer) {
+	systemID := "HGX_Baseboard_0"
+
+	// Define test GPUs
+	testGPUs := []testGPUConfig{
+		{ID: "GPU_0", Name: "GPU 0", Temperature: 58.0},
+		{ID: "GPU_1", Name: "GPU 1", Temperature: 59.5},
+	}
+
+	// Build processor collection members
+	members := make([]map[string]string, len(testGPUs))
+	for i, gpu := range testGPUs {
+		members[i] = map[string]string{
+			"@odata.id": fmt.Sprintf("/redfish/v1/Systems/%s/Processors/%s", systemID, gpu.ID),
+		}
+	}
+
+	// Add processors collection
+	server.addRoute(fmt.Sprintf("/redfish/v1/Systems/%s/Processors", systemID), map[string]interface{}{
+		"@odata.type":          "#ProcessorCollection.ProcessorCollection",
+		"Members":              members,
+		"Members@odata.count": len(members),
+	})
+
+	// Add each GPU processor and its temperature sensor
+	for _, gpu := range testGPUs {
+		// Add processor
+		processorPath := fmt.Sprintf("/redfish/v1/Systems/%s/Processors/%s", systemID, gpu.ID)
+		server.addRoute(processorPath, createGPUProcessor(systemID, gpu.ID, gpu.Name))
+
+		// Add temperature sensor
+		chassisID := fmt.Sprintf("HGX_%s", gpu.ID)
+		sensorID := fmt.Sprintf("%s_TEMP_1", chassisID)
+		sensorPath := fmt.Sprintf("/redfish/v1/Chassis/%s/Sensors/%s", chassisID, sensorID)
+		server.addRoute(sensorPath, createTemperatureSensor(chassisID, sensorID, gpu.Temperature))
+	}
+}
 
 // collectAndCategorizeMetrics collects metrics and categorizes them
 func collectAndCategorizeMetrics(t *testing.T, collector *GPUCollector) (map[string]float64, map[string]float64, map[string]float64, int) {
@@ -178,10 +257,24 @@ func categorizeMetric(metric prometheus.Metric, dto *dto.Metric, gpuMemory, gpuP
 	if processorID == "GPU_0" {
 		categorizeProcessorMetric(descString, dto, gpuProcessor)
 	}
-	
+
 	// Categorize NVLink port metrics
 	if strings.Contains(portID, "NVLink") {
 		categorizeNVLinkMetric(descString, dto, nvlink)
+	}
+
+	// Categorize GPU temperature metrics
+	if strings.Contains(descString, "temperature_tlimit_celsius") {
+		gpuID := ""
+		for _, label := range dto.Label {
+			if label.GetName() == "gpu_id" {
+				gpuID = label.GetValue()
+				break
+			}
+		}
+		if gpuID != "" {
+			gpuProcessor["temperature_tlimit_"+gpuID] = dto.Gauge.GetValue()
+		}
 	}
 }
 
@@ -233,60 +326,143 @@ func categorizeNVLinkMetric(descString string, dto *dto.Metric, metrics map[stri
 // verifyGPUMemoryMetrics verifies GPU memory metrics
 func verifyGPUMemoryMetrics(t *testing.T, metrics map[string]float64) {
 	if len(metrics) == 0 {
-		t.Error("No GPU memory metrics were collected")
+		t.Fatal("No GPU memory metrics were collected")
 	}
-	
-	// Check GPU_0 metrics
-	if val, ok := metrics["row_remapping_failed_GPU_0_DRAM_0"]; ok {
-		if val != 0 {
-			t.Errorf("Expected GPU_0 row_remapping_failed = 0, got %f", val)
-		}
-	} else {
-		t.Error("GPU_0 row_remapping_failed metric not collected")
+
+	tests := []struct {
+		metricKey     string
+		expectedValue float64
+		description   string
+		required      bool
+	}{
+		{
+			metricKey:     "row_remapping_failed_GPU_0_DRAM_0",
+			expectedValue: 0,
+			description:   "GPU_0 row_remapping_failed",
+			required:      true,
+		},
+		{
+			metricKey:     "row_remapping_failed_GPU_1_DRAM_0",
+			expectedValue: 1,
+			description:   "GPU_1 row_remapping_failed",
+			required:      true,
+		},
+		{
+			metricKey:     "max_availability_bank_count",
+			expectedValue: 5952,
+			description:   "max_availability_bank_count",
+			required:      false, // OEM data might not always be present
+		},
 	}
-	
-	// Check GPU_1 metrics
-	if val, ok := metrics["row_remapping_failed_GPU_1_DRAM_0"]; ok {
-		if val != 1 {
-			t.Errorf("Expected GPU_1 row_remapping_failed = 1, got %f", val)
-		}
-	} else {
-		t.Error("GPU_1 row_remapping_failed metric not collected")
-	}
-	
-	// Check OEM data
-	if val, ok := metrics["max_availability_bank_count"]; ok {
-		if val != 5952 {
-			t.Errorf("Expected max_availability_bank_count = 5952, got %f", val)
-		}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			val, ok := metrics[tt.metricKey]
+			if !ok {
+				if tt.required {
+					t.Errorf("%s metric not collected", tt.description)
+				}
+				return
+			}
+			if val != tt.expectedValue {
+				t.Errorf("Expected %s = %f, got %f", tt.description, tt.expectedValue, val)
+			}
+		})
 	}
 }
 
+
+// verifyGPUTemperatureMetrics verifies GPU temperature metrics
+func verifyGPUTemperatureMetrics(t *testing.T, metrics map[string]float64) {
+	tests := []struct {
+		metricKey     string
+		expectedValue float64
+		description   string
+	}{
+		{
+			metricKey:     "temperature_tlimit_GPU_0",
+			expectedValue: 58.0,
+			description:   "GPU_0 temperature",
+		},
+		{
+			metricKey:     "temperature_tlimit_GPU_1",
+			expectedValue: 59.5,
+			description:   "GPU_1 temperature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			val, ok := metrics[tt.metricKey]
+			if !ok {
+				t.Errorf("%s metric not collected", tt.description)
+				return
+			}
+			if val != tt.expectedValue {
+				t.Errorf("Expected %s = %f, got %f", tt.description, tt.expectedValue, val)
+			}
+		})
+	}
+}
 
 // TestGPUCollectorWithNvidiaGPU tests the GPU collector with Nvidia GPU hardware
 func TestGPUCollectorWithNvidiaGPU(t *testing.T) {
 	server := setupTestServerWithGPU(t)
 	client := connectToTestServer(t, server)
 	defer client.Logout()
-	
+
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	collector := NewGPUCollector(client, logger)
-	
-	gpuMemoryMetrics, _, _, metricsFound := collectAndCategorizeMetrics(t, collector)
-	
-	if metricsFound == 0 {
-		t.Error("No metrics were collected")
-	}
-	
+
+	gpuMemoryMetrics, gpuProcessorMetrics, _, metricsFound := collectAndCategorizeMetrics(t, collector)
+
+	require.NotZero(t, metricsFound, "No metrics were collected")
+
 	verifyGPUMemoryMetrics(t, gpuMemoryMetrics)
-	
+	verifyGPUTemperatureMetrics(t, gpuProcessorMetrics)
+
 	t.Logf("Successfully collected %d total metrics", metricsFound)
 	t.Logf("GPU memory metrics: %d", len(gpuMemoryMetrics))
+	t.Logf("GPU processor/temperature metrics: %d", len(gpuProcessorMetrics))
 }
 
 // TestGPUCollectorWithNoGPUs tests the GPU collector when no GPUs are present
 func TestGPUCollectorWithNoGPUs(t *testing.T) {
-	// Create a test server with no GPU hardware
+	server := setupTestServerWithoutGPU(t)
+	client := connectToTestServer(t, server)
+	defer client.Logout()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	collector := NewGPUCollector(client, logger)
+
+	ch := make(chan prometheus.Metric, 100)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	gpuMetricsFound := 0
+	for metric := range ch {
+		dto := &dto.Metric{}
+		if err := metric.Write(dto); err != nil {
+			continue
+		}
+
+		desc := metric.Desc()
+		descString := desc.String()
+
+		if isGPUSpecificMetric(descString) {
+			gpuMetricsFound++
+			t.Errorf("Unexpected GPU metric found: %s", descString)
+		}
+	}
+
+	assert.Zero(t, gpuMetricsFound, "Found GPU metrics when none were expected")
+	t.Log("Successfully verified no GPU metrics collected for non-GPU system")
+}
+
+// setupTestServerWithoutGPU creates a test server without GPU hardware
+func setupTestServerWithoutGPU(t *testing.T) *testRedfishServer {
 	server := &testRedfishServer{
 		t:        t,
 		mux:      http.NewServeMux(),
@@ -294,11 +470,9 @@ func TestGPUCollectorWithNoGPUs(t *testing.T) {
 	}
 	server.Server = httptest.NewServer(server.mux)
 	t.Cleanup(server.Close)
-	
-	// Add service root
+
 	server.addRouteFromFixture("/redfish/v1/", "service_root.json")
-	
-	// Add systems collection with regular system
+
 	server.addRoute("/redfish/v1/Systems", map[string]interface{}{
 		"@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
 		"Members": []map[string]string{
@@ -306,8 +480,16 @@ func TestGPUCollectorWithNoGPUs(t *testing.T) {
 		},
 		"Members@odata.count": 1,
 	})
-	
-	// Add regular system without GPU components
+
+	setupNonGPUSystem(server)
+	setupNonGPUMemory(server)
+	setupNonGPUProcessors(server)
+
+	return server
+}
+
+// setupNonGPUSystem adds a regular system without GPU components
+func setupNonGPUSystem(server *testRedfishServer) {
 	server.addRoute("/redfish/v1/Systems/System1", map[string]interface{}{
 		"@odata.type": "#ComputerSystem.v1_14_0.ComputerSystem",
 		"@odata.id":   "/redfish/v1/Systems/System1",
@@ -327,8 +509,10 @@ func TestGPUCollectorWithNoGPUs(t *testing.T) {
 			"@odata.id": "/redfish/v1/Systems/System1/Processors",
 		},
 	})
-	
-	// Add Memory collection with only regular memory
+}
+
+// setupNonGPUMemory adds regular memory without GPU memory
+func setupNonGPUMemory(server *testRedfishServer) {
 	server.addRoute("/redfish/v1/Systems/System1/Memory", map[string]interface{}{
 		"@odata.type": "#MemoryCollection.MemoryCollection",
 		"Members": []map[string]string{
@@ -337,8 +521,7 @@ func TestGPUCollectorWithNoGPUs(t *testing.T) {
 		},
 		"Members@odata.count": 2,
 	})
-	
-	// Add regular DIMMs
+
 	server.addRoute("/redfish/v1/Systems/System1/Memory/DIMM_0", map[string]interface{}{
 		"@odata.type": "#Memory.v1_17_0.Memory",
 		"@odata.id":   "/redfish/v1/Systems/System1/Memory/DIMM_0",
@@ -351,8 +534,10 @@ func TestGPUCollectorWithNoGPUs(t *testing.T) {
 			"Health": "OK",
 		},
 	})
-	
-	// Add Processor collection with only CPUs
+}
+
+// setupNonGPUProcessors adds CPU processors without GPUs
+func setupNonGPUProcessors(server *testRedfishServer) {
 	server.addRoute("/redfish/v1/Systems/System1/Processors", map[string]interface{}{
 		"@odata.type": "#ProcessorCollection.ProcessorCollection",
 		"Members": []map[string]string{
@@ -361,8 +546,7 @@ func TestGPUCollectorWithNoGPUs(t *testing.T) {
 		},
 		"Members@odata.count": 2,
 	})
-	
-	// Add CPU processors
+
 	server.addRoute("/redfish/v1/Systems/System1/Processors/CPU_0", map[string]interface{}{
 		"@odata.type": "#Processor.v1_14_0.Processor",
 		"@odata.id":   "/redfish/v1/Systems/System1/Processors/CPU_0",
@@ -376,48 +560,23 @@ func TestGPUCollectorWithNoGPUs(t *testing.T) {
 			"Health": "OK",
 		},
 	})
-	
-	// Connect to the test server
-	client := connectToTestServer(t, server)
-	defer client.Logout()
-	
-	// Create GPU collector
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	collector := NewGPUCollector(client, logger)
-	
-	// Collect metrics
-	ch := make(chan prometheus.Metric, 100)
-	go func() {
-		collector.Collect(ch)
-		close(ch)
-	}()
-	
-	// Check that no GPU-specific metrics are collected
-	gpuMetricsFound := 0
-	for metric := range ch {
-		dto := &dto.Metric{}
-		if err := metric.Write(dto); err != nil {
-			continue
-		}
-		
-		desc := metric.Desc()
-		descString := desc.String()
-		
-		// Check if this is a GPU-specific metric (should not find any)
-		if strings.Contains(descString, "gpu_") || 
-		   strings.Contains(descString, "nvlink") ||
-		   strings.Contains(descString, "tensor_core") ||
-		   strings.Contains(descString, "sm_utilization") {
-			gpuMetricsFound++
-			t.Errorf("Unexpected GPU metric found: %s", descString)
+}
+
+// isGPUSpecificMetric checks if a metric is GPU-specific
+func isGPUSpecificMetric(descString string) bool {
+	gpuIndicators := []string{
+		"gpu_",
+		"nvlink",
+		"tensor_core",
+		"sm_utilization",
+	}
+
+	for _, indicator := range gpuIndicators {
+		if strings.Contains(descString, indicator) {
+			return true
 		}
 	}
-	
-	if gpuMetricsFound > 0 {
-		t.Errorf("Found %d GPU metrics when none were expected", gpuMetricsFound)
-	}
-	
-	t.Log("Successfully verified no GPU metrics collected for non-GPU system")
+	return false
 }
 
 // TestCollectGPUProcessorMetrics tests collection of GPU processor metrics with various health states

--- a/collector/testdata/gpu_temperature_sensor.json
+++ b/collector/testdata/gpu_temperature_sensor.json
@@ -1,0 +1,23 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/HGX_GPU_0/Sensors/HGX_GPU_0_TEMP_1",
+  "@odata.type": "#Sensor.v1_7_0.Sensor",
+  "Description": "Thermal Limit(TLIMIT) Temperature is the distance in deg C from the GPU temperature to the first throttle limit.",
+  "Id": "HGX_GPU_0_TEMP_1",
+  "Implementation": "Synthesized",
+  "Name": "HGX GPU 0 TEMP 1",
+  "PhysicalContext": "GPU",
+  "Reading": 58.0,
+  "ReadingBasis": "Headroom",
+  "ReadingType": "Temperature",
+  "ReadingUnits": "Cel",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "Thresholds": {
+    "LowerCritical": {
+      "Reading": 0,
+      "Activation": "Decreasing"
+    }
+  }
+}


### PR DESCRIPTION
Adds GPU TLIMIT temperature metric collection from NVIDIA OEM Redfish endpoints and improves concurrency patterns in the GPU collector.

**New Metric**
- redfish_gpu_temperature_tlimit_celsius: Collects GPU thermal limit (TLIMIT) temperature headroom in Celsius from chassis sensor endpoints
  - Fetched from /redfish/v1/Chassis/HGX_GPU_X/Sensors/HGX_GPU_X_TEMP_1 endpoints
  - Dynamically discovers GPUs

**Code Improvements**
- Fixed resource leak: Resolved defer-in-loop issue where HTTP response bodies were accumulating until function return
- Improved concurrency:
  - Added parallel temperature sensor collection with semaphore-based throttling (max 5 concurrent requests)
  - Added semaphore limiting for GPU memory and processor metric collection
  - Properly captured loop variables in goroutine closures
- Test stability: Fixed brittle test that was comparing protobuf string representations; now validates metric values and labels

**Testing**
- Verified temperature metrics are collected for all 4 GPUs in mock server
- All existing tests pass
- Confirmed no performance degradation with concurrent collection

```
# HELP redfish_gpu_temperature_tlimit_celsius GPU TLIMIT temperature headroom in Celsius
# TYPE redfish_gpu_temperature_tlimit_celsius gauge
redfish_gpu_temperature_tlimit_celsius{gpu_id="GPU_0",hostname="HGX_Baseboard_0",system_id="HGX_Baseboard_0"} 58
redfish_gpu_temperature_tlimit_celsius{gpu_id="GPU_1",hostname="HGX_Baseboard_0",system_id="HGX_Baseboard_0"} 58.5
redfish_gpu_temperature_tlimit_celsius{gpu_id="GPU_2",hostname="HGX_Baseboard_0",system_id="HGX_Baseboard_0"} 57.84375
redfish_gpu_temperature_tlimit_celsius{gpu_id="GPU_3",hostname="HGX_Baseboard_0",system_id="HGX_Baseboard_0"} 58.15625
```