### PR TITLE
adding redfish_gpu_memory_power_watts metric

### DIFF
--- a/collector/gpu_collector.go
+++ b/collector/gpu_collector.go
@@ -125,6 +125,9 @@ func createGPUMetricMap() map[string]Metric {
 	// GPU Temperature sensor metrics
 	addToMetricMap(gpuMetrics, GPUSubsystem, "temperature_tlimit_celsius", "GPU TLIMIT temperature headroom in Celsius", gpuBaseLabels)
 
+	// GPU Memory Power metrics
+	addToMetricMap(gpuMetrics, GPUSubsystem, "memory_power_watts", "GPU memory (DRAM) power consumption in watts", gpuMemoryLabels)
+
 	return gpuMetrics
 }
 
@@ -195,6 +198,9 @@ func (g *GPUCollector) Collect(ch chan<- prometheus.Metric) {
 
 	// Collect GPU temperature sensors using gathered GPU info
 	g.collectGPUTemperatureSensors(ch, allSystemGPUs)
+
+	// Collect GPU memory power sensors using gathered GPU info
+	g.collectGPUMemoryPowerSensors(ch, allSystemGPUs)
 
 	g.collectorScrapeStatus.WithLabelValues("gpu").Set(float64(1))
 }
@@ -678,6 +684,81 @@ func (g *GPUCollector) collectSingleGPUTemperature(ch chan<- prometheus.Metric, 
 
 	ch <- prometheus.MustNewConstMetric(
 		g.metrics["gpu_temperature_tlimit_celsius"].desc,
+		prometheus.GaugeValue,
+		float64(sensor.Reading),
+		labels...,
+	)
+}
+
+// collectGPUMemoryPowerSensors collects GPU memory power consumption from Chassis sensors
+func (g *GPUCollector) collectGPUMemoryPowerSensors(ch chan<- prometheus.Metric, allSystemGPUs []systemGPUInfo) {
+	wg := &sync.WaitGroup{}
+	// Limit concurrent requests to avoid overwhelming the server
+	sem := make(chan struct{}, 5)
+
+	for _, sysInfo := range allSystemGPUs {
+		for _, gpu := range sysInfo.gpus {
+			// Assuming each GPU has DRAM_0, we can extend this if there are multiple DRAMs
+			// Pattern: HGX_GPU_{gpu_id}_DRAM_0_Power_0
+			wg.Add(1)
+			go func(gpuID, systemName, systemID string) {
+				defer wg.Done()
+				sem <- struct{}{}        // Acquire semaphore
+				defer func() { <-sem }() // Release semaphore
+
+				// For now, assume DRAM_0. Could be extended to discover all DRAMs
+				memoryID := fmt.Sprintf("%s_DRAM_0", gpuID)
+				g.collectSingleMemoryPower(ch, gpuID, memoryID, systemName, systemID)
+			}(gpu.ID, sysInfo.systemName, sysInfo.systemID)
+		}
+	}
+
+	wg.Wait()
+}
+
+// collectSingleMemoryPower collects power for a single GPU memory module
+func (g *GPUCollector) collectSingleMemoryPower(ch chan<- prometheus.Metric, gpuID, memoryID, systemName, systemID string) {
+	// Construct the chassis sensor path for this GPU memory power
+	// Pattern: /redfish/v1/Chassis/HGX_{gpuID}/Sensors/HGX_{memoryID}_Power_0
+	chassisID := fmt.Sprintf("HGX_%s", gpuID)
+	sensorPath := fmt.Sprintf("/redfish/v1/Chassis/%s/Sensors/HGX_%s_Power_0", chassisID, memoryID)
+
+	// Use gofish to get the sensor
+	sensor, err := redfish.GetSensor(g.redfishClient, sensorPath)
+	if err != nil {
+		g.logger.Debug("failed to fetch GPU memory power sensor",
+			slog.String("gpu_id", gpuID),
+			slog.String("memory_id", memoryID),
+			slog.String("path", sensorPath),
+			slog.Any("error", err),
+		)
+		return
+	}
+
+	// Verify it's a power sensor (defensive check)
+	if sensor.ReadingType != redfish.PowerReadingType {
+		g.logger.Warn("sensor is not a power type",
+			slog.String("gpu_id", gpuID),
+			slog.String("memory_id", memoryID),
+			slog.String("actual_type", string(sensor.ReadingType)),
+		)
+		return
+	}
+
+	// Log additional sensor info if in debug mode
+	g.logger.Debug("collected GPU memory power sensor",
+		slog.String("gpu_id", gpuID),
+		slog.String("memory_id", memoryID),
+		slog.Float64("reading", float64(sensor.Reading)),
+		slog.String("units", string(sensor.ReadingUnits)),
+		slog.String("status", string(sensor.Status.Health)),
+	)
+
+	// Emit the power metric
+	labels := []string{systemName, systemID, gpuID, memoryID}
+
+	ch <- prometheus.MustNewConstMetric(
+		g.metrics["gpu_memory_power_watts"].desc,
 		prometheus.GaugeValue,
 		float64(sensor.Reading),
 		labels...,


### PR DESCRIPTION
**New Metric**
- redfish_gpu_memory_power_watts: GPU memory (DRAM) power consumption in watts
  - Collected from /redfish/v1/Chassis/HGX_GPU_X/Sensors/HGX_GPU_X_DRAM_0_Power_0 endpoints


**Implementation**
- Leverages existing systemGPUInfo channel pattern from temperature collection
- Uses gofish.GetSensor() for type-safe sensor access
- Includes defensive ReadingType validation for data integrity
- Assumes single DRAM module per GPU (DRAM_0)

**Testing**
- Added test fixtures for power sensors
- Extended existing GPU tests to verify power metric collection
- Tests verify expected power values (36.5W, 38W)
- All existing tests continue to pass


```
# HELP redfish_gpu_memory_power_watts GPU memory (DRAM) power consumption in watts
# TYPE redfish_gpu_memory_power_watts gauge
redfish_gpu_memory_power_watts{gpu_id="GPU_0",hostname="HGX_Baseboard_0",memory_id="GPU_0_DRAM_0",system_id="HGX_Baseboard_0"} 36.569000244140625
redfish_gpu_memory_power_watts{gpu_id="GPU_1",hostname="HGX_Baseboard_0",memory_id="GPU_1_DRAM_0",system_id="HGX_Baseboard_0"} 37.95000076293945
redfish_gpu_memory_power_watts{gpu_id="GPU_2",hostname="HGX_Baseboard_0",memory_id="GPU_2_DRAM_0",system_id="HGX_Baseboard_0"} 36.005001068115234
redfish_gpu_memory_power_watts{gpu_id="GPU_3",hostname="HGX_Baseboard_0",memory_id="GPU_3_DRAM_0",system_id="HGX_Baseboard_0"} 34.51900100708008
```