### PR TITLE
adding performance testing tool, make targets, and enable http connec…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ package.json
 package-lock.json
 
 # Mock server test data
+tools/mock-server/mock-server
 tools/mock-server/testdata/
 tools/mock-server/server.crt
 tools/mock-server/server.key
@@ -36,3 +37,7 @@ tools/mock-server/exporter-config.yml
 
 # Capture binary
 tools/capture/capture
+
+# Performance analysis
+tools/performance-analysis/analyze
+tools/performance-analysis/temp-config.yml

--- a/collector/redfish_collector.go
+++ b/collector/redfish_collector.go
@@ -110,10 +110,11 @@ func newRedfishClient(host string, username string, password string) (*gofish.AP
 	url := fmt.Sprintf("https://%s", host)
 
 	config := gofish.ClientConfig{
-		Endpoint: url,
-		Username: username,
-		Password: password,
-		Insecure: true,
+		Endpoint:         url,
+		Username:         username,
+		Password:         password,
+		Insecure:         true,
+		ReuseConnections: true, // Enable HTTP keepalive for connection reuse
 	}
 	redfishClient, err := gofish.Connect(config)
 	if err != nil {

--- a/tools/performance-analysis/README.md
+++ b/tools/performance-analysis/README.md
@@ -1,0 +1,122 @@
+# Performance Analysis Tool
+
+This tool analyzes the performance of redfish_exporter scrapes to identify bottlenecks and measure latency.
+
+## Quick Start
+
+### Test against mock server
+```bash
+make perf-mock
+```
+
+### Test against live system
+
+Using existing config.yml:
+```bash
+make perf-live TARGET=192.168.1.100
+```
+
+With credentials via environment:
+```bash
+REDFISH_USER=admin REDFISH_PASS=password make perf-live TARGET=192.168.1.100
+```
+
+### With options
+```bash
+# Run 10 iterations with verbose output
+make perf-live TARGET=192.168.1.100 RUNS=10 VERBOSE=1
+
+# With credentials and options
+REDFISH_USER=admin REDFISH_PASS=password make perf-live TARGET=192.168.1.100 RUNS=10 VERBOSE=1
+```
+
+## Credentials
+
+The tool handles credentials in two ways:
+
+1. **Using config.yml** (default)
+   - Looks for `config.yml` in the project root
+   - Must contain host credentials in the standard format
+
+2. **Using environment variables**
+   - Set `REDFISH_USER` and `REDFISH_PASS`
+   - A temporary config file is created and cleaned up automatically
+   - Useful for CI/CD or when testing different credentials
+
+## What it measures
+
+- **Scrape Duration**: Total time to complete a scrape
+- **Metrics Count**: Number of metrics collected
+- **Statistics**: Min/max/average/percentiles across multiple runs
+- **Collector Timing**: Time spent in each collector (when available)
+
+## Direct Usage
+
+You can also run the analyzer directly:
+
+```bash
+cd tools/performance-analysis
+go build -o analyze analyze.go
+
+# Test against a target
+./analyze -target 192.168.1.100 -endpoint http://localhost:9610 -runs 5 -verbose
+
+# Output as JSON
+./analyze -target 192.168.1.100 -format json
+```
+
+## Options
+
+- `-target`: Target to scrape (required)
+- `-endpoint`: Redfish exporter endpoint (default: http://localhost:9610)
+- `-runs`: Number of test runs (default: 1)
+- `-verbose`: Show detailed timing information
+- `-format`: Output format - "text" or "json" (default: text)
+
+## Understanding the Results
+
+### Basic Metrics
+- **Duration**: Total time for the HTTP request to /redfish endpoint
+- **Metrics**: Total number of Prometheus metrics returned
+
+### Statistics (multiple runs)
+- **P50**: Median response time
+- **P95**: 95th percentile (95% of requests are faster)
+- **P99**: 99th percentile (99% of requests are faster)
+
+### Performance Analysis
+
+The tool helps identify whether performance issues are due to:
+1. **Network/API latency**: Time spent waiting for Redfish API responses
+2. **Processing overhead**: Time spent parsing and creating metrics
+3. **Specific collectors**: Which collector is taking the most time
+
+## Example Output
+
+```
+=== Performance Analysis Summary ===
+Successful scrapes: 5/5
+Average duration: 5.645ms
+Average metrics: 33
+Min duration: 1.291ms
+Max duration: 14.296ms
+P50 duration: 2.541ms
+P95 duration: 14.296ms
+P99 duration: 14.296ms
+```
+
+## Troubleshooting
+
+If the mock server doesn't start:
+```bash
+# Manually start mock server
+cd tools/mock-server
+go build -o mock-server main.go
+./mock-server -port 8000 -file testdata/gb300/gb300_host.txt
+```
+
+If the exporter isn't running:
+```bash
+# Manually start exporter
+./redfish_exporter --config.file=config.yml
+```

--- a/tools/performance-analysis/analyze.go
+++ b/tools/performance-analysis/analyze.go
@@ -1,0 +1,591 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/expfmt"
+)
+
+// ScrapeResult holds the results of a scrape
+type ScrapeResult struct {
+	Target         string
+	Duration       time.Duration
+	MetricsCount   int
+	Error          error
+	CollectorTimes map[string]time.Duration // From redfish_exporter_collector_duration_seconds
+	RedfishUp      float64 // Value of redfish_up metric (0 = failed, 1 = success)
+	ScrapeSuccess  bool    // Whether this was a successful hardware scrape
+}
+
+// Config holds the configuration for the analysis
+type Config struct {
+	Target   string
+	Endpoint string // redfish_exporter endpoint
+	Runs     int
+	Verbose  bool
+	Format   string // "text" or "json"
+
+	// Comparison mode
+	CompareMode  bool
+	MockTarget   string
+	MockEndpoint string
+	LiveTarget   string
+	LiveEndpoint string
+}
+
+func main() {
+	var config Config
+
+	// Single target mode
+	flag.StringVar(&config.Target, "target", "", "Target to scrape (IP or hostname)")
+	flag.StringVar(&config.Endpoint, "endpoint", "http://localhost:9610", "Redfish exporter endpoint")
+	flag.IntVar(&config.Runs, "runs", 1, "Number of scrape runs to perform")
+	flag.BoolVar(&config.Verbose, "verbose", false, "Verbose output")
+	flag.StringVar(&config.Format, "format", "text", "Output format (text or json)")
+
+	// Comparison mode
+	flag.BoolVar(&config.CompareMode, "compare", false, "Enable comparison mode")
+	flag.StringVar(&config.MockTarget, "mock", "localhost:8443", "Mock server target (for comparison)")
+	flag.StringVar(&config.MockEndpoint, "mock-endpoint", "http://localhost:9610", "Mock exporter endpoint")
+	flag.StringVar(&config.LiveTarget, "live", "", "Live system target (for comparison)")
+	flag.StringVar(&config.LiveEndpoint, "live-endpoint", "http://localhost:9611", "Live exporter endpoint")
+	flag.Parse()
+
+	if config.CompareMode {
+		// Comparison mode
+		if config.LiveTarget == "" {
+			fmt.Fprintf(os.Stderr, "Error: -live target is required in comparison mode\n")
+			flag.Usage()
+			os.Exit(1)
+		}
+		runComparison(config)
+	} else {
+		// Single target mode
+		if config.Target == "" {
+			fmt.Fprintf(os.Stderr, "Error: -target is required\n")
+			flag.Usage()
+			os.Exit(1)
+		}
+		runAnalysis(config)
+	}
+
+}
+
+func runAnalysis(config Config) {
+	results := make([]ScrapeResult, config.Runs)
+
+	fmt.Printf("Analyzing performance for target: %s\n", config.Target)
+	fmt.Printf("Using exporter at: %s\n", config.Endpoint)
+	fmt.Printf("Running %d scrape(s)...\n\n", config.Runs)
+
+	for i := 0; i < config.Runs; i++ {
+		if config.Runs > 1 {
+			fmt.Printf("Run %d/%d: ", i+1, config.Runs)
+		}
+
+		result := performScrape(config)
+		results[i] = result
+
+		if result.Error != nil {
+			fmt.Printf("ERROR: %v\n", result.Error)
+		} else if !result.ScrapeSuccess {
+			fmt.Printf("FAILED: Duration: %v, redfish_up=%v (only %d exporter metrics)\n",
+				result.Duration, result.RedfishUp, result.MetricsCount)
+		} else {
+			fmt.Printf("Duration: %v, Metrics: %d\n", result.Duration, result.MetricsCount)
+		}
+
+		if config.Verbose && result.CollectorTimes != nil {
+			fmt.Println("  Collector timings:")
+			for collector, duration := range result.CollectorTimes {
+				fmt.Printf("    %s: %v\n", collector, duration)
+			}
+		}
+	}
+
+	// Print summary
+	printSummary(results, config)
+}
+
+func runComparison(config Config) {
+	fmt.Println("=== Redfish Performance Comparison ===")
+	fmt.Printf("Mock target: %s\n", config.MockTarget)
+	fmt.Printf("Live target: %s\n", config.LiveTarget)
+	fmt.Printf("Running %d scrapes for each target...\n\n", config.Runs)
+
+	// Test mock server
+	fmt.Println("Testing MOCK server...")
+	mockResults := make([]ScrapeResult, config.Runs)
+	for i := 0; i < config.Runs; i++ {
+		fmt.Printf("  Run %d/%d: ", i+1, config.Runs)
+		result := performScrape(Config{
+			Target:   config.MockTarget,
+			Endpoint: config.MockEndpoint,
+		})
+		mockResults[i] = result
+
+		if result.Error != nil {
+			fmt.Printf("ERROR: %v\n", result.Error)
+		} else if !result.ScrapeSuccess {
+			fmt.Printf("FAILED: %v (redfish_up=%v, only %d metrics)\n",
+				result.Duration, result.RedfishUp, result.MetricsCount)
+		} else {
+			fmt.Printf("%v (%d metrics)\n", result.Duration, result.MetricsCount)
+		}
+	}
+
+	// Test live system
+	fmt.Println("\nTesting LIVE system...")
+	liveResults := make([]ScrapeResult, config.Runs)
+	for i := 0; i < config.Runs; i++ {
+		fmt.Printf("  Run %d/%d: ", i+1, config.Runs)
+		result := performScrape(Config{
+			Target:   config.LiveTarget,
+			Endpoint: config.LiveEndpoint,
+		})
+		liveResults[i] = result
+
+		if result.Error != nil {
+			fmt.Printf("ERROR: %v\n", result.Error)
+		} else if !result.ScrapeSuccess {
+			fmt.Printf("FAILED: %v (redfish_up=%v, only %d metrics)\n",
+				result.Duration, result.RedfishUp, result.MetricsCount)
+		} else {
+			fmt.Printf("%v (%d metrics)\n", result.Duration, result.MetricsCount)
+		}
+	}
+
+	// Analyze and compare
+	printComparisonSummary(mockResults, liveResults, config)
+}
+
+func performScrape(config Config) ScrapeResult {
+	result := ScrapeResult{
+		Target:         config.Target,
+		CollectorTimes: make(map[string]time.Duration),
+	}
+
+	// Build the URL
+	url := fmt.Sprintf("%s/redfish?target=%s", config.Endpoint, config.Target)
+
+	// Perform the scrape
+	start := time.Now()
+	resp, err := http.Get(url)
+	result.Duration = time.Since(start)
+
+	if err != nil {
+		result.Error = fmt.Errorf("failed to scrape: %w", err)
+		return result
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		result.Error = fmt.Errorf("scrape failed with status %d: %s", resp.StatusCode, string(body))
+		return result
+	}
+
+	// Parse the metrics
+	parser := expfmt.TextParser{}
+	metricFamilies, err := parser.TextToMetricFamilies(resp.Body)
+	if err != nil {
+		result.Error = fmt.Errorf("failed to parse metrics: %w", err)
+		return result
+	}
+
+	// Count metrics and extract important indicators
+	result.RedfishUp = 0 // Default to failed
+	for name, mf := range metricFamilies {
+		result.MetricsCount += len(mf.Metric)
+
+		// Check if scrape was successful
+		if name == "redfish_up" {
+			for _, metric := range mf.Metric {
+				if metric.Gauge != nil && metric.Gauge.Value != nil {
+					result.RedfishUp = *metric.Gauge.Value
+				}
+			}
+		}
+
+		// Extract collector duration metrics
+		if name == "redfish_exporter_collector_duration_seconds" {
+			for _, metric := range mf.Metric {
+				if metric.Gauge != nil && metric.Gauge.Value != nil {
+					// The metric doesn't have labels in the current implementation,
+					// but we track the total duration
+					result.CollectorTimes["total"] = time.Duration(*metric.Gauge.Value * float64(time.Second))
+				}
+			}
+		}
+
+		// Extract per-collector scrape durations if available
+		if strings.HasSuffix(name, "_scrape_duration_seconds") {
+			for _, metric := range mf.Metric {
+				if metric.Gauge != nil && metric.Gauge.Value != nil {
+					collectorName := strings.TrimSuffix(name, "_scrape_duration_seconds")
+					result.CollectorTimes[collectorName] = time.Duration(*metric.Gauge.Value * float64(time.Second))
+				}
+			}
+		}
+	}
+
+	// Determine if this was a successful hardware scrape
+	// Failed scrapes typically return ~30-40 exporter-only metrics
+	result.ScrapeSuccess = result.RedfishUp == 1 && result.MetricsCount > 50
+
+	return result
+}
+
+func printSummary(results []ScrapeResult, config Config) {
+	if len(results) == 0 {
+		return
+	}
+
+	fmt.Println("\n=== Performance Analysis Summary ===")
+
+	// Calculate statistics
+	var totalDuration time.Duration
+	var totalMetrics int
+	var successCount int
+	durations := make([]time.Duration, 0, len(results))
+
+	var failedScrapes int
+	for _, r := range results {
+		if r.Error == nil && r.ScrapeSuccess {
+			totalDuration += r.Duration
+			totalMetrics += r.MetricsCount
+			successCount++
+			durations = append(durations, r.Duration)
+		} else if r.Error == nil && !r.ScrapeSuccess {
+			failedScrapes++
+		}
+	}
+
+	if successCount == 0 {
+		fmt.Println("\n✗ No successful scrapes")
+		if failedScrapes > 0 {
+			fmt.Printf("All %d scrapes failed (redfish_up=0)\n", failedScrapes)
+			fmt.Println("\nLikely causes:")
+			fmt.Println("  • Authentication failed (check username/password)")
+			fmt.Println("  • Target is not reachable (check network/firewall)")
+			fmt.Println("  • Target is not a valid Redfish endpoint")
+			fmt.Println("  • TLS certificate issues (if using HTTPS)")
+			fmt.Println("\nDebug steps:")
+			fmt.Println("  1. Check exporter logs: journalctl -u redfish_exporter -n 50")
+			fmt.Println("  2. Test connectivity: curl -k https://<target>/redfish/v1/")
+			fmt.Println("  3. Verify credentials in config file")
+		}
+		return
+	}
+
+	// Calculate average
+	avgDuration := totalDuration / time.Duration(successCount)
+	avgMetrics := totalMetrics / successCount
+
+	fmt.Printf("Successful scrapes: %d/%d", successCount, len(results))
+	if failedScrapes > 0 {
+		fmt.Printf(" (%d failed with redfish_up=0)", failedScrapes)
+	}
+	fmt.Println()
+	fmt.Printf("Average duration: %v\n", avgDuration)
+	fmt.Printf("Average metrics: %d\n", avgMetrics)
+
+	if len(durations) > 1 {
+		// Sort durations for percentiles
+		sort.Slice(durations, func(i, j int) bool {
+			return durations[i] < durations[j]
+		})
+
+		fmt.Printf("Min duration: %v\n", durations[0])
+		fmt.Printf("Max duration: %v\n", durations[len(durations)-1])
+
+		// Calculate percentiles
+		p50 := durations[len(durations)*50/100]
+		p95 := durations[len(durations)*95/100]
+		p99 := durations[len(durations)*99/100]
+
+		fmt.Printf("P50 duration: %v\n", p50)
+		fmt.Printf("P95 duration: %v\n", p95)
+		fmt.Printf("P99 duration: %v\n", p99)
+	}
+
+	// Analyze performance and identify bottlenecks
+	fmt.Println("\n=== Performance Analysis ===")
+
+	// Determine performance category based on average duration
+	if avgDuration < 100*time.Millisecond {
+		fmt.Printf("✓ EXCELLENT: Average scrape time is %v (< 100ms)\n", avgDuration)
+	} else if avgDuration < 1*time.Second {
+		fmt.Printf("✓ GOOD: Average scrape time is %v (< 1s)\n", avgDuration)
+	} else if avgDuration < 10*time.Second {
+		fmt.Printf("⚠ SLOW: Average scrape time is %v (1s - 10s)\n", avgDuration)
+		fmt.Println("  This may cause issues with Prometheus scrape intervals")
+	} else if avgDuration < 30*time.Second {
+		fmt.Printf("⚠ VERY SLOW: Average scrape time is %v (10s - 30s)\n", avgDuration)
+		fmt.Println("  This will likely cause Prometheus timeouts with default settings")
+	} else {
+		fmt.Printf("✗ CRITICAL: Average scrape time is %v (> 30s)\n", avgDuration)
+		fmt.Println("  Scrapes are taking too long and will timeout in most configurations")
+	}
+
+	// Analyze variance to identify consistency issues
+	if len(durations) > 1 {
+		variance := durations[len(durations)-1] - durations[0]
+		if variance > avgDuration/2 {
+			fmt.Printf("\n⚠ HIGH VARIANCE: Response times vary by %v\n", variance)
+			fmt.Println("  This suggests intermittent performance issues")
+		}
+	}
+
+	// Identify likely bottlenecks based on duration patterns
+	fmt.Println("\n=== Likely Bottlenecks ===")
+
+	if avgDuration > 30*time.Second {
+		fmt.Println("With scrape times > 30 seconds, likely causes:")
+		fmt.Println("  1. Network latency or packet loss to BMC")
+		fmt.Println("  2. BMC is overloaded or slow to respond")
+		fmt.Println("  3. Too many resources being enumerated (many chassis/systems)")
+		fmt.Println("  4. Authentication delays or session management issues")
+		fmt.Println("\nRecommendations:")
+		fmt.Println("  • Check network connectivity to BMC (ping, traceroute)")
+		fmt.Println("  • Verify BMC firmware is up to date")
+		fmt.Println("  • Consider reducing scrape frequency")
+		fmt.Println("  • Check if BMC has rate limiting enabled")
+	} else if avgDuration > 10*time.Second {
+		fmt.Println("With scrape times 10-30 seconds, likely causes:")
+		fmt.Println("  1. Large number of components being scraped")
+		fmt.Println("  2. Slow BMC response times")
+		fmt.Println("  3. Sequential processing of many resources")
+		fmt.Println("\nRecommendations:")
+		fmt.Println("  • Review which collectors are needed")
+		fmt.Println("  • Consider filtering unnecessary metrics")
+		fmt.Println("  • Check BMC performance and load")
+	} else if avgDuration > 1*time.Second {
+		fmt.Println("With scrape times 1-10 seconds:")
+		fmt.Println("  • Performance is acceptable but could be improved")
+		fmt.Println("  • Consider caching if scraping frequently")
+		fmt.Println("  • Monitor for degradation over time")
+	}
+
+	// Compare mock vs live performance if both available
+	if config.Target != "localhost:8000" && config.Target != "localhost" {
+		fmt.Println("\n=== Performance Comparison ===")
+		fmt.Println("To identify if delays are network/BMC related, compare with mock:")
+		fmt.Println("  make perf-mock  # Test with mock server")
+		fmt.Printf("  Current target (%s): %v average\n", config.Target, avgDuration)
+		fmt.Println("\nIf mock is significantly faster (< 100ms), the issue is:")
+		fmt.Println("  • Network latency to BMC")
+		fmt.Println("  • BMC processing speed")
+		fmt.Println("  • Number of resources on actual hardware")
+	}
+
+	// Metrics analysis
+	if avgMetrics > 0 {
+		metricsPerSecond := float64(avgMetrics) / avgDuration.Seconds()
+		fmt.Printf("\n=== Metrics Efficiency ===\n")
+		fmt.Printf("Metrics collected: %d\n", avgMetrics)
+		fmt.Printf("Metrics per second: %.1f\n", metricsPerSecond)
+
+		if metricsPerSecond < 10 {
+			fmt.Println("⚠ LOW THROUGHPUT: Less than 10 metrics/second")
+			fmt.Println("  This indicates significant overhead per metric")
+		} else if metricsPerSecond < 100 {
+			fmt.Println("⚠ MODERATE THROUGHPUT: 10-100 metrics/second")
+		} else {
+			fmt.Printf("✓ GOOD THROUGHPUT: %.1f metrics/second\n", metricsPerSecond)
+		}
+	}
+
+	// Output JSON if requested
+	if config.Format == "json" {
+		fmt.Println("\n=== JSON Output ===")
+		output := map[string]interface{}{
+			"target":         config.Target,
+			"runs":           len(results),
+			"successful":     successCount,
+			"avg_duration":   avgDuration.Seconds(),
+			"avg_metrics":    avgMetrics,
+			"results":        results,
+		}
+
+		jsonData, err := json.MarshalIndent(output, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
+		} else {
+			fmt.Println(string(jsonData))
+		}
+	}
+}
+
+func printComparisonSummary(mockResults, liveResults []ScrapeResult, config Config) {
+	// Calculate statistics
+	mockStats := calculateStats(mockResults)
+	liveStats := calculateStats(liveResults)
+
+	if mockStats.count == 0 || liveStats.count == 0 {
+		fmt.Println("\n✗ Unable to compare - scrapes failed")
+		if mockStats.count == 0 {
+			fmt.Println("  Mock server scrapes failed (redfish_up=0)")
+			fmt.Println("  Check that mock server is running on localhost:8000")
+			fmt.Println("  Check exporter config has correct credentials for mock")
+		}
+		if liveStats.count == 0 {
+			fmt.Println("  Live system scrapes failed (redfish_up=0)")
+			fmt.Println("  Check credentials (REDFISH_USER/REDFISH_PASS)")
+			fmt.Println("  Verify network connectivity to target")
+			fmt.Println("  Check if target has valid Redfish API")
+		}
+		return
+	}
+
+	// Calculate comparison metrics
+	speedupFactor := float64(liveStats.avg) / float64(mockStats.avg)
+	networkOverhead := liveStats.avg - mockStats.avg
+	overheadPercent := (float64(networkOverhead) / float64(liveStats.avg)) * 100
+
+	fmt.Println("\n=== Performance Summary ===")
+	fmt.Printf("%-20s %15s %15s\n", "Target", "Mock", "Live")
+	fmt.Printf("%-20s %15s %15s\n", "─────────────────", "───────────", "───────────")
+	fmt.Printf("%-20s %15v %15v\n", "Average Duration", mockStats.avg, liveStats.avg)
+	fmt.Printf("%-20s %15v %15v\n", "Min Duration", mockStats.min, liveStats.min)
+	fmt.Printf("%-20s %15v %15v\n", "Max Duration", mockStats.max, liveStats.max)
+	fmt.Printf("%-20s %15d %15d\n", "Avg Metrics", mockStats.metrics, liveStats.metrics)
+	fmt.Printf("%-20s %15.1f %15.1f\n", "Metrics/sec", mockStats.throughput, liveStats.throughput)
+
+	fmt.Println("\n=== Performance Comparison ===")
+	fmt.Printf("Live system is %.1fx slower than mock\n", speedupFactor)
+	fmt.Printf("Network/BMC overhead: %v (%.1f%% of total time)\n",
+		networkOverhead, overheadPercent)
+
+	// Identify bottleneck
+	var bottleneck string
+	if speedupFactor < 2 {
+		bottleneck = "Processing/Code (similar performance between mock and live)"
+	} else if speedupFactor < 10 {
+		bottleneck = "Mixed (both network and processing contribute)"
+	} else if speedupFactor < 100 {
+		bottleneck = "Network latency or BMC response time"
+	} else {
+		bottleneck = "Severe network/BMC issues or resource enumeration"
+	}
+
+	fmt.Println("\n=== Bottleneck Analysis ===")
+	fmt.Printf("Primary bottleneck: %s\n", bottleneck)
+
+	// Provide recommendations
+	fmt.Println("\n=== Recommendations ===")
+	if speedupFactor > 100 {
+		fmt.Println("✗ CRITICAL PERFORMANCE GAP")
+		fmt.Println("  The live system is >100x slower than mock, indicating:")
+		fmt.Println("  • Severe network issues (check connectivity, packet loss)")
+		fmt.Println("  • BMC is overloaded or unresponsive")
+		fmt.Println("  • Possible authentication/session issues")
+		fmt.Println("\nImmediate actions:")
+		fmt.Println("  1. Check network path to BMC (ping, traceroute)")
+		fmt.Println("  2. Verify BMC is not rate-limiting requests")
+		fmt.Println("  3. Check BMC CPU/memory usage")
+		fmt.Println("  4. Review BMC logs for errors")
+	} else if speedupFactor > 10 {
+		fmt.Println("⚠ SIGNIFICANT PERFORMANCE GAP")
+		fmt.Println("  The live system is 10-100x slower, indicating:")
+		fmt.Println("  • High network latency to BMC")
+		fmt.Println("  • Slow BMC response times")
+		fmt.Println("  • Large number of hardware components")
+		fmt.Println("\nRecommended actions:")
+		fmt.Println("  1. Optimize network path to BMC")
+		fmt.Println("  2. Consider BMC firmware updates")
+		fmt.Println("  3. Reduce scrape frequency if possible")
+	} else if speedupFactor > 2 {
+		fmt.Println("⚠ MODERATE PERFORMANCE GAP")
+		fmt.Println("  The live system is 2-10x slower")
+		fmt.Println("  This is expected for remote BMC access")
+		fmt.Println("\nOptimizations to consider:")
+		fmt.Println("  1. Implement caching if appropriate")
+		fmt.Println("  2. Filter unnecessary metrics")
+		fmt.Println("  3. Monitor for degradation over time")
+	} else {
+		fmt.Println("✓ MINIMAL PERFORMANCE GAP")
+		fmt.Println("  Mock and live performance are similar")
+		fmt.Println("  This suggests the bottleneck is in the exporter code itself")
+		fmt.Println("\nCode optimizations needed:")
+		fmt.Println("  1. Profile the exporter code")
+		fmt.Println("  2. Optimize parallel processing")
+		fmt.Println("  3. Review data parsing efficiency")
+	}
+
+	// Component breakdown if very slow
+	if liveStats.avg > 30*time.Second {
+		fmt.Println("\n=== Component Analysis ===")
+		fmt.Println("With scrape times >30s on live system:")
+		fmt.Printf("Processing rate: %.2f metrics/second\n", liveStats.throughput)
+
+		if mockStats.metrics > 0 && liveStats.metrics > mockStats.metrics {
+			componentRatio := float64(liveStats.metrics) / float64(mockStats.metrics)
+			fmt.Printf("Live system has ~%.1fx more metrics than mock\n", componentRatio)
+			fmt.Println("Consider if all components need to be scraped")
+		}
+	}
+
+	if config.Verbose {
+		fmt.Println("\n=== Detailed Metrics ===")
+		fmt.Printf("Mock: successful=%d, failed=%d\n",
+			mockStats.count, len(mockResults)-mockStats.count)
+		fmt.Printf("Live: successful=%d, failed=%d\n",
+			liveStats.count, len(liveResults)-liveStats.count)
+	}
+}
+
+type stats struct {
+	avg        time.Duration
+	min        time.Duration
+	max        time.Duration
+	metrics    int
+	throughput float64
+	count      int
+}
+
+func calculateStats(results []ScrapeResult) stats {
+	var total time.Duration
+	var count, metrics int
+	var min, max time.Duration
+
+	for _, r := range results {
+		if r.Error == nil && r.ScrapeSuccess {
+			total += r.Duration
+			metrics += r.MetricsCount
+			count++
+
+			if min == 0 || r.Duration < min {
+				min = r.Duration
+			}
+			if r.Duration > max {
+				max = r.Duration
+			}
+		}
+	}
+
+	if count == 0 {
+		return stats{}
+	}
+
+	avg := total / time.Duration(count)
+	avgMetrics := metrics / count
+	throughput := float64(avgMetrics) / avg.Seconds()
+
+	return stats{
+		avg:        avg,
+		min:        min,
+		max:        max,
+		metrics:    avgMetrics,
+		throughput: throughput,
+		count:      count,
+	}
+}

--- a/tools/performance-analysis/run-analysis.sh
+++ b/tools/performance-analysis/run-analysis.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+
+# Performance analysis script for redfish_exporter
+# Can test against mock servers or real hardware
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+EXPORTER_PORT=${EXPORTER_PORT:-9610}
+EXPORTER_URL="http://localhost:${EXPORTER_PORT}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS] <mode> <target>
+
+Modes:
+  mock        Test against mock server
+  live        Test against live system
+
+Options:
+  -r RUNS     Number of test runs (default: 5)
+  -v          Verbose output
+  -p PORT     Exporter port (default: 9610)
+  -c CONFIG   Config file for exporter (default: config.yml for live, tools/mock-server/exporter-config.yml for mock)
+  -h          Show this help
+
+Examples:
+  # Test against mock server
+  $0 mock localhost:8000
+
+  # Test against live system
+  $0 live 192.168.1.100
+
+  # Run 10 iterations with verbose output
+  $0 -r 10 -v live 192.168.1.100
+EOF
+    exit 1
+}
+
+# Parse arguments
+RUNS=5
+VERBOSE=""
+CONFIG_FILE=""
+
+while getopts "r:vp:c:h" opt; do
+    case $opt in
+        r) RUNS="$OPTARG" ;;
+        v) VERBOSE="-verbose" ;;
+        p) EXPORTER_PORT="$OPTARG" ;;
+        c) CONFIG_FILE="$OPTARG" ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+if [ $# -lt 2 ]; then
+    echo -e "${RED}Error: Mode and target are required${NC}"
+    usage
+fi
+
+MODE="$1"
+TARGET="$2"
+
+# Validate mode
+if [ "$MODE" != "mock" ] && [ "$MODE" != "live" ]; then
+    echo -e "${RED}Error: Invalid mode '$MODE'. Must be 'mock' or 'live'${NC}"
+    usage
+fi
+
+# Set config file based on mode if not specified
+if [ -z "$CONFIG_FILE" ]; then
+    if [ "$MODE" = "mock" ]; then
+        CONFIG_FILE="${PROJECT_ROOT}/tools/mock-server/exporter-config.yml"
+    else
+        CONFIG_FILE="${PROJECT_ROOT}/config.yml"
+
+        # For live mode, check if we need to create/update config
+        if [ "$MODE" = "live" ]; then
+            # Check if credentials were provided via environment
+            if [ ! -z "$REDFISH_USER" ] && [ ! -z "$REDFISH_PASS" ]; then
+                echo "Creating temporary config with provided credentials..."
+                CONFIG_FILE="${PROJECT_ROOT}/tools/performance-analysis/temp-config.yml"
+                cat > "$CONFIG_FILE" <<EOF
+hosts:
+  default:
+    username: ${REDFISH_USER}
+    password: ${REDFISH_PASS}
+  ${TARGET}:
+    username: ${REDFISH_USER}
+    password: ${REDFISH_PASS}
+loglevel: info
+EOF
+                TEMP_CONFIG=1
+            elif [ ! -f "$CONFIG_FILE" ]; then
+                echo -e "${RED}Error: No config.yml found and no credentials provided${NC}"
+                echo "Please either:"
+                echo "  1. Create a config.yml with credentials"
+                echo "  2. Set REDFISH_USER and REDFISH_PASS environment variables"
+                echo ""
+                echo "Example:"
+                echo "  REDFISH_USER=admin REDFISH_PASS=password make perf-live TARGET=192.168.1.100"
+                exit 1
+            fi
+        fi
+    fi
+fi
+
+echo -e "${GREEN}=== Redfish Exporter Performance Analysis ===${NC}"
+echo "Mode: $MODE"
+echo "Target: $TARGET"
+echo "Runs: $RUNS"
+echo "Config: $CONFIG_FILE"
+echo ""
+
+# For live mode with temp config, always restart the exporter
+# For other modes, only start if not running
+if [ "$TEMP_CONFIG" = "1" ] || ! curl -s "${EXPORTER_URL}/metrics" > /dev/null 2>&1; then
+    if [ "$TEMP_CONFIG" = "1" ]; then
+        echo -e "${YELLOW}Restarting exporter with temporary config...${NC}"
+    else
+        echo -e "${YELLOW}Warning: Exporter not running on port ${EXPORTER_PORT}${NC}"
+        echo "Starting exporter..."
+    fi
+
+    # Kill any existing exporter
+    pkill -f redfish_exporter || true
+    sleep 1
+
+    # Build if needed
+    if [ ! -f "${PROJECT_ROOT}/redfish_exporter" ]; then
+        echo "Building redfish_exporter..."
+        (cd "${PROJECT_ROOT}" && go build)
+    fi
+
+    # Start exporter in background
+    "${PROJECT_ROOT}/redfish_exporter" --config.file="$CONFIG_FILE" --web.listen-address=":${EXPORTER_PORT}" &
+    EXPORTER_PID=$!
+    echo "Started exporter with PID ${EXPORTER_PID}"
+
+    # Wait for it to be ready
+    echo -n "Waiting for exporter to be ready..."
+    for i in {1..30}; do
+        if curl -s "${EXPORTER_URL}/metrics" > /dev/null 2>&1; then
+            echo " Ready!"
+            break
+        fi
+        echo -n "."
+        sleep 1
+    done
+    echo ""
+fi
+
+# If mock mode, ensure mock server is running
+if [ "$MODE" = "mock" ]; then
+    MOCK_PORT=$(echo "$TARGET" | cut -d: -f2)
+    if [ -z "$MOCK_PORT" ]; then
+        MOCK_PORT="8443"
+        TARGET="localhost:8443"
+    fi
+
+    if ! curl -s "https://localhost:${MOCK_PORT}/redfish/v1/" > /dev/null 2>&1; then
+        echo -e "${YELLOW}Warning: Mock server not running on port ${MOCK_PORT}${NC}"
+        echo "Starting mock server..."
+
+        # Kill any existing mock server
+        pkill -f "mock-server.*${MOCK_PORT}" || true
+        sleep 1
+
+        # Build mock server if needed
+        if [ ! -f "${PROJECT_ROOT}/tools/mock-server/mock-server" ]; then
+            echo "Building mock server..."
+            (cd "${PROJECT_ROOT}/tools/mock-server" && go build -o mock-server main.go)
+        fi
+
+        # Start mock server with default test data
+        TESTDATA="${PROJECT_ROOT}/tools/mock-server/testdata/gb300/gb300_host.txt"
+        (cd "${PROJECT_ROOT}/tools/mock-server" && ./mock-server -auth auth.yml -port "${MOCK_PORT}" -file "${TESTDATA}" > /dev/null 2>&1) &
+        MOCK_PID=$!
+        echo "Started mock server with PID ${MOCK_PID}"
+
+        # Wait for it to be ready
+        echo -n "Waiting for mock server to be ready..."
+        for i in {1..30}; do
+            if curl -s "https://localhost:${MOCK_PORT}/redfish/v1/" > /dev/null 2>&1; then
+                echo " Ready!"
+                break
+            fi
+            echo -n "."
+            sleep 1
+        done
+        echo ""
+    fi
+fi
+
+# Build the analyzer if needed
+echo "Building performance analyzer..."
+(cd "${SCRIPT_DIR}" && go build -o analyze analyze.go)
+
+# Run the analysis
+echo -e "\n${GREEN}Running performance analysis...${NC}\n"
+"${SCRIPT_DIR}/analyze" \
+    -target "$TARGET" \
+    -endpoint "${EXPORTER_URL}" \
+    -runs "$RUNS" \
+    $VERBOSE
+
+# Cleanup if we started services
+if [ ! -z "$EXPORTER_PID" ]; then
+    echo -e "\n${YELLOW}Stopping exporter (PID ${EXPORTER_PID})${NC}"
+    kill "$EXPORTER_PID" 2>/dev/null || true
+fi
+
+if [ ! -z "$MOCK_PID" ]; then
+    echo -e "${YELLOW}Stopping mock server (PID ${MOCK_PID})${NC}"
+    kill "$MOCK_PID" 2>/dev/null || true
+fi
+
+# Clean up temporary config file
+if [ "$TEMP_CONFIG" = "1" ] && [ -f "${PROJECT_ROOT}/tools/performance-analysis/temp-config.yml" ]; then
+    echo -e "${YELLOW}Removing temporary config file${NC}"
+    rm -f "${PROJECT_ROOT}/tools/performance-analysis/temp-config.yml"
+fi
+
+echo -e "\n${GREEN}Analysis complete!${NC}"


### PR DESCRIPTION
Enables HTTP connection reuse in the gofish client, reducing scrape time by ~40%. Also adds performance analysis tools to identify bottlenecks.

**Key Changes**
- collector/redfish_collector.go: Added ReuseConnections: true as a default setting to eliminate redundant TLS handshakes
- tools/performance-analysis/: New tool for analyzing scrape performance and comparing mock vs live systems
- Makefile updated with targets for:
  - perf-live: runs against a provided live system to show latency in a production system
  - perf-mock: runs against a completely local system to show redfish_exporter latency in isolation
  - perf-compare: runs both live and mock and provides a comparison

**Impact**
Previously, every Redfish API request created a new HTTPS connection. With 38 chassis and multiple sub-requests per chassis,
this caused hundreds of unnecessary connection setups. Connection reuse eliminates this overhead.

**Testing**
make perf-live REDFISH_USER=username REDFISH_PASS=password TARGET=some_ip
showed a 40% reduction in latency when using the ReuseConnections parameter
