### PR TITLE
adding GPU profiling metrics

### DIFF
--- a/collector/telemetry_collector_test.go
+++ b/collector/telemetry_collector_test.go
@@ -249,6 +249,7 @@ func TestTelemetryMetricCount(t *testing.T) {
 		"memory":        5,  // ecc lifetime (2), bandwidth, capacity_util, operating_speed
 		"reset":         8,  // conventional entry/exit, fundamental entry/exit, irot exit, pf_flr entry/exit, last_reset_type
 		"port":          23, // port metrics (speed, rx/tx bytes/frames/errors, link down counts, OEM metrics)
+		"nvidia_gpm":    22, // GPU Performance Monitoring: 11 compute + 2 aggregate media + 2 instance media + 5 network + 2 PCIe
 		"scrape_status": 1,  // collector status
 	}
 


### PR DESCRIPTION
  ## Summary
  Adds support for HGX_ProcessorGPMMetrics_0 (GPU Performance Monitoring) telemetry collection, providing deep profiling metrics for NVIDIA GPU compute units, media engines, and interconnects.

  ## Changes
  - Added 22 new telemetry metrics with `nvidia_` prefix following OEM naming conventions
  - Implemented `collectGPMMetrics()` function to handle both base and per-instance metrics
  - Added whitelist-based validation for instance metrics (NVDec/NVJpg instances 0-7)
  - Updated test expectations to include GPM metrics (74 total metric descriptors)
  - Removed duplicate metrics from gpu_collector.go, the TelemetryService endpoint should be more performant at collecting them. 

  ## Metrics Added
  **Compute Unit Utilization (11 metrics)**
  - Tensor cores, Streaming Multiprocessors (activity/occupancy)
  - FP16/FP32/FP64 and integer operations
  - DMMA/HMMA/IMMA (matrix multiply-accumulate units)
  - Graphics engine activity

  **Media Engine Utilization (4 metrics)**
  - NVDec/NVJpg aggregate utilization
  - NVDec/NVJpg per-instance utilization (8 instances each)

  **Network Bandwidth (5 metrics)**
  - NVLink data/raw RX/TX bandwidth
  - NVOfa (Optimized Fabrics Adapter) utilization

  **PCIe Bandwidth (2 metrics)**
  - Raw RX/TX bandwidth

  ## Testing
  - All existing tests pass
  - New test coverage added for GPM metric count
  - Performance against live system remains constant