### PR TITLE
Drop and instrument stale reports

### DIFF
--- a/collector/telemetry_collector_test.go
+++ b/collector/telemetry_collector_test.go
@@ -727,7 +727,9 @@ func TestTelemetryCollector_CollectPlatformGPUMetrics(t *testing.T) {
 				if m.Gauge != nil {
 					require.False(t, math.IsNaN(*m.GetGauge().Value))
 				}
-
+				if strings.Contains(metric.Desc().String(), "stale_reports_last") {
+					require.GreaterOrEqual(t, m.GetGauge().GetValue(), 1.0)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
#34 describes a condition where the TelemetryService may emit one or more 'stale' reports.
Right now the exporter is consuming these stale reports and ultimately emitting `NaN` values back to telemetry systems.

A stale report does not necessarily mean a GPU is idle or broken, and so an approach of emitting a zero value is more confusing than a NaN, IMO.

The desired action should be to drop reportedly stale reports, while still giving operators a means to know if there's a possible problem.

This PR does that and solves #34. If a TelemetryService report contains a marker for staleness in the `Oem` JSON, or the value is `nan`, it gets dropped.
We also emit a gauge for the last known quantity of stale telemetry reports, so an operator can know there's an issue.

(also has some minor formatting fixes)

When built locally and pointed to a symptomatic host, I see:

```
# HELP redfish_telemetry_collection_stale_reports_last Quantity of stale reports discovered on the last collection loop
# TYPE redfish_telemetry_collection_stale_reports_last gauge
redfish_telemetry_collection_stale_reports_last 13
```
which tracks with the real quantity of NaNs the host is giving right now.

Further, current NaNs like:
```
# HELP redfish_telemetry_gpu_power_watts GPU power consumption in watts
# TYPE redfish_telemetry_gpu_power_watts gauge
redfish_telemetry_gpu_power_watts{gpu_id="GPU_0",hostname="HGX_Baseboard_0",system_id="HGX_Baseboard_0"} NaN
redfish_telemetry_gpu_power_watts{gpu_id="GPU_1",hostname="HGX_Baseboard_0",system_id="HGX_Baseboard_0"} NaN
redfish_telemetry_gpu_power_watts{gpu_id="GPU_2",hostname="HGX_Baseboard_0",system_id="HGX_Baseboard_0"} NaN
redfish_telemetry_gpu_power_watts{gpu_id="GPU_3",hostname="HGX_Baseboard_0",system_id="HGX_Baseboard_0"} NaN
```
are dropped as expected when pointed to the same symptomatic host.