### PR TITLE
Feature: Emit GPU firmware in gpu_info timeseries

### DIFF
--- a/internal/collector/gpu_collector.go
+++ b/internal/collector/gpu_collector.go
@@ -27,7 +27,7 @@ var (
 	// gpuPortLabels appends NVLink labels gpuBaseLabels for NVLink-related series
 	gpuPortLabels = baseWithExtraLabels([]string{"port_id", "port_type", "port_protocol"})
 	// gpuInfoLabels appends a S/N and UUID to gpuBaseLabels for the redfish_gpu_info series
-	gpuInfoLabels = baseWithExtraLabels([]string{"serial_number", "uuid"})
+	gpuInfoLabels = baseWithExtraLabels([]string{"firmware_version", "serial_number", "uuid"})
 	gpuMetrics    = createGPUMetricMap()
 )
 
@@ -377,14 +377,18 @@ func (g *GPUCollector) emitHealthInfo(ch chan<- prometheus.Metric, gpu SystemGPU
 			procBaseLabels...,
 		)
 	}
-	var gpuSerial, gpuUUID string
+	var gpuFirmware, gpuSerial, gpuUUID string
 	if gpuSerial = gpu.SerialNumber; gpuSerial == "" {
 		gpuSerial = "unknown"
 	}
 	if gpuUUID = gpu.UUID; gpuUUID == "" {
 		gpuUUID = "unknown"
 	}
-	infoLabels := []string{gpu.SystemName, gpu.ID, gpuSerial, gpuUUID}
+	if gpuFirmware = gpu.FirmwareVersion; gpuFirmware == "" {
+		gpuFirmware = "unknown"
+	}
+
+	infoLabels := []string{gpu.SystemName, gpu.ID, gpuFirmware, gpuSerial, gpuUUID}
 	ch <- prometheus.MustNewConstMetric(
 		g.metrics["gpu_info"].desc,
 		prometheus.GaugeValue,

--- a/internal/collector/gpu_collector_test.go
+++ b/internal/collector/gpu_collector_test.go
@@ -214,10 +214,10 @@ redfish_gpu_health{gpu_id="GPU_2",system_id="HGX_Baseboard_0"} 1
 redfish_gpu_health{gpu_id="GPU_3",system_id="HGX_Baseboard_0"} 2
 # HELP redfish_gpu_info GPU information with serial number and UUID
 # TYPE redfish_gpu_info gauge
-redfish_gpu_info{gpu_id="GPU_0",serial_number="123456",system_id="HGX_Baseboard_0",uuid="gpu-0-uuid"} 1
-redfish_gpu_info{gpu_id="GPU_1",serial_number="234567",system_id="HGX_Baseboard_0",uuid="gpu-1-uuid"} 1
-redfish_gpu_info{gpu_id="GPU_2",serial_number="345678",system_id="HGX_Baseboard_0",uuid="gpu-2-uuid"} 1
-redfish_gpu_info{gpu_id="GPU_3",serial_number="456789",system_id="HGX_Baseboard_0",uuid="gpu-3-uuid"} 1
+redfish_gpu_info{firmware_version="97.10.3E.00.05",gpu_id="GPU_0",serial_number="123456",system_id="HGX_Baseboard_0",uuid="gpu-0-uuid"} 1
+redfish_gpu_info{firmware_version="97.10.3E.00.05",gpu_id="GPU_1",serial_number="234567",system_id="HGX_Baseboard_0",uuid="gpu-1-uuid"} 1
+redfish_gpu_info{firmware_version="97.10.3E.00.05",gpu_id="GPU_2",serial_number="345678",system_id="HGX_Baseboard_0",uuid="gpu-2-uuid"} 1
+redfish_gpu_info{firmware_version="97.10.3E.00.05",gpu_id="GPU_3",serial_number="456789",system_id="HGX_Baseboard_0",uuid="gpu-3-uuid"} 1
 # HELP redfish_gpu_state GPU processor state,1(Enabled),2(Disabled),3(StandbyOffinline),4(StandbySpare),5(InTest),6(Starting),7(Absent),8(UnavailableOffline),9(Deferring),10(Quiesced),11(Updating)
 # TYPE redfish_gpu_state gauge
 redfish_gpu_state{gpu_id="GPU_0",system_id="HGX_Baseboard_0"} 1
@@ -234,8 +234,8 @@ redfish_gpu_state{gpu_id="GPU_3",system_id="HGX_Baseboard_0"} 5
 			wantSeriesString: `
 # HELP redfish_gpu_info GPU information with serial number and UUID
 # TYPE redfish_gpu_info gauge
-redfish_gpu_info{gpu_id="GPU_SXM_1",serial_number="unknown",system_id="HGX_Baseboard_0",uuid="unknown"} 1
-redfish_gpu_info{gpu_id="GPU_SXM_2",serial_number="unknown",system_id="HGX_Baseboard_0",uuid="unknown"} 1
+redfish_gpu_info{firmware_version="unknown",gpu_id="GPU_SXM_1",serial_number="unknown",system_id="HGX_Baseboard_0",uuid="unknown"} 1
+redfish_gpu_info{firmware_version="unknown",gpu_id="GPU_SXM_2",serial_number="unknown",system_id="HGX_Baseboard_0",uuid="unknown"} 1
 `,
 		},
 	}

--- a/internal/collector/testdata/gpu_info_unknown_multi/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_1/index.json
+++ b/internal/collector/testdata/gpu_info_unknown_multi/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_1/index.json
@@ -19,7 +19,6 @@
   "EnvironmentMetrics": {
     "@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_1/EnvironmentMetrics"
   },
-  "FirmwareVersion": "97.00.7F.00.04",
   "Id": "GPU_SXM_1",
   "Links": {
     "Chassis": {

--- a/internal/collector/testdata/gpu_info_unknown_multi/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_2/index.json
+++ b/internal/collector/testdata/gpu_info_unknown_multi/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_2/index.json
@@ -19,7 +19,6 @@
   "EnvironmentMetrics": {
     "@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_2/EnvironmentMetrics"
   },
-  "FirmwareVersion": "97.00.7F.00.04",
   "Id": "GPU_SXM_2",
   "Links": {
     "Chassis": {


### PR DESCRIPTION
As noted from a commit message, this dimension has a lot of value for teams managing fleets of GPU nodes, and may even be helpful for tuning alerts where firmware could be a variable (e.g. B200s with a "66-day lockup" issue).

This change emits `firmware_version` as a label. It does not totally track with an OTel Semconv I just learned about: https://opentelemetry.io/docs/specs/semconv/hardware/gpu/ but is still very close and in spirit with what the exporter is doing and also matches the label from another collector (manager collector)