### PR TITLE
Added counters for successful scrapes.

### DIFF
--- a/cmd/redfish-exporter/main.go
+++ b/cmd/redfish-exporter/main.go
@@ -70,6 +70,11 @@ var (
 		Name: "redfish_exporter_scrape_requests_total",
 		Help: "Total number of scrape requests received per target, regardless of success or failure.",
 	}, []string{"target"})
+	// scrapeSuccessesTotal counts scrapes where all sub-collectors completed without failure.
+	scrapeSuccessesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "redfish_exporter_scrape_successes_total",
+		Help: "Total number of scrapes where all sub-collectors completed successfully for the target.",
+	}, []string{"target"})
 )
 
 func reloadHandler() http.HandlerFunc {
@@ -101,6 +106,7 @@ func registerMetaMetrics() {
 		collectorLastStatus,
 		collectorModuleUnknown,
 		scrapeRequestsTotal,
+		scrapeSuccessesTotal,
 	}
 
 	prometheus.DefaultRegisterer.MustRegister(custom...)
@@ -219,6 +225,10 @@ func metricsHandler() http.HandlerFunc {
 		// Delegate http serving to Prometheus client library, which will call collector.Collect.
 		h := promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{})
 		h.ServeHTTP(w, r)
+
+		if _, failed := aggregateCollector.CollectorOutcome(); failed == 0 {
+			scrapeSuccessesTotal.WithLabelValues(sr.Target).Inc()
+		}
 	}
 }
 

--- a/cmd/redfish-exporter/main_test.go
+++ b/cmd/redfish-exporter/main_test.go
@@ -356,6 +356,53 @@ func TestScrapeRequestsTotal(t *testing.T) {
 	})
 }
 
+// TestScrapeSuccessesTotal verifies that redfish_exporter_scrape_successes_total is incremented
+// only when all sub-collectors in the scrape session completed without failure.
+func TestScrapeSuccessesTotal(t *testing.T) {
+	safeConfig = config.NewSafeConfig("")
+
+	t.Run("increments when all collectors succeed", func(t *testing.T) {
+		// A TLS server that responds with minimal valid JSON allows NewRedfishCollector
+		// to connect and all (stub) collectors to complete without panicking.
+		rfServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"@odata.id": r.URL.Path})
+		}))
+		t.Cleanup(rfServer.Close)
+
+		target := rfServer.Listener.Addr().String()
+		before := testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target))
+
+		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(target, nil))
+
+		assert.Equal(t, before+1, testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target)))
+	})
+
+	t.Run("does not increment when connection fails", func(t *testing.T) {
+		// An unreachable target means NewRedfishCollector fails and no collectors run,
+		// so CollectorOutcome() returns failed > 0 and the success counter must not increment.
+		target := "unreachable-success.test:1"
+		before := testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target))
+
+		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(target, nil))
+
+		assert.Equal(t, before, testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target)))
+	})
+
+	t.Run("requests and successes counters are independent", func(t *testing.T) {
+		// Verifies that a failed scrape increments requests but not successes,
+		// so the difference between the two counters reflects the failure count.
+		target := "independent-counters.test:1"
+		beforeReqs := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target))
+		beforeSucc := testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target))
+
+		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(target, nil))
+
+		assert.Equal(t, beforeReqs+1, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target)))
+		assert.Equal(t, beforeSucc, testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target)))
+	})
+}
+
 func TestBuildCollectorsFor(t *testing.T) {
 	moduleConfig := map[string]config.Module{
 		"chassis_collector": {Prober: "chassis_collector"},

--- a/internal/collector/redfish_collector.go
+++ b/internal/collector/redfish_collector.go
@@ -31,6 +31,16 @@ var (
 		"Collector time duration.",
 		nil, nil,
 	)
+	collectorsSucceededDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, exporter, "collectors_succeeded"),
+		"Number of sub-collectors that completed successfully in the most recent scrape.",
+		nil, nil,
+	)
+	collectorsFailedDesc = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, exporter, "collectors_failed"),
+		"Number of sub-collectors that failed (panicked) in the most recent scrape.",
+		nil, nil,
+	)
 )
 
 // redfishCollector is an aggregation of various other prometheus.Collector.
@@ -45,9 +55,9 @@ type redfishCollector struct {
 
 	// collectorsSucceeded and collectorsFailed track how many sub-collectors
 	// completed successfully or failed in the most recent Collect() call.
-	// They are reset to zero at the start of each Collect(). collectorSucceeded is 
-	// incremented as sub-collector goroutines complete. collectorsFailed is derived 
-	// at the end of Collect() as the difference between total collectors and successful 
+	// They are reset to zero at the start of each Collect(). collectorSucceeded is
+	// incremented as sub-collector goroutines complete. collectorsFailed is derived
+	// at the end of Collect() as the difference between total collectors and successful
 	// ones.
 	collectorsSucceeded atomic.Int64
 	collectorsFailed    atomic.Int64
@@ -80,6 +90,12 @@ func (r *redfishCollector) WithCollectors(c []ContextAwareCollector) {
 	r.collectors = c
 }
 
+// CollectorOutcome returns the number of sub-collectors that succeeded and failed
+// in the most recent Collect() session. Values are meaningful only after Collect() returns.
+func (r *redfishCollector) CollectorOutcome() (succeeded, failed int64) {
+	return r.collectorsSucceeded.Load(), r.collectorsFailed.Load()
+}
+
 func (r *redfishCollector) Client() *gofish.APIClient {
 	return r.redfishClient
 }
@@ -89,7 +105,8 @@ func (r *redfishCollector) Describe(ch chan<- *prometheus.Desc) {
 	for _, collector := range r.collectors {
 		collector.Describe(ch)
 	}
-
+	ch <- collectorsSucceededDesc
+	ch <- collectorsFailedDesc
 }
 
 // Collect implements prometheus.Collector.
@@ -124,6 +141,8 @@ func (r *redfishCollector) Collect(ch chan<- prometheus.Metric) {
 
 	ch <- r.redfishUp
 	ch <- prometheus.MustNewConstMetric(totalScrapeDurationDesc, prometheus.GaugeValue, time.Since(scrapeTime).Seconds())
+	ch <- prometheus.MustNewConstMetric(collectorsSucceededDesc, prometheus.GaugeValue, float64(r.collectorsSucceeded.Load()))
+	ch <- prometheus.MustNewConstMetric(collectorsFailedDesc, prometheus.GaugeValue, float64(r.collectorsFailed.Load()))
 }
 
 type collectorCtxKey struct{}

--- a/internal/collector/redfish_collector.go
+++ b/internal/collector/redfish_collector.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -41,6 +42,13 @@ type redfishCollector struct {
 	redfishClient *gofish.APIClient
 	collectors    []ContextAwareCollector
 	redfishUp     prometheus.Gauge
+
+	// collectorsSucceeded and collectorsFailed track how many sub-collectors
+	// completed successfully or failed in the most recent Collect() call.
+	// They are reset to zero at the start of each Collect() and incremented
+	// as sub-collector goroutines complete.
+	collectorsSucceeded atomic.Int64
+	collectorsFailed    atomic.Int64
 }
 
 // NewRedfishCollector returns a *redfishCollector or an error.
@@ -84,6 +92,9 @@ func (r *redfishCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect implements prometheus.Collector.
 func (r *redfishCollector) Collect(ch chan<- prometheus.Metric) {
+	r.collectorsSucceeded.Store(0)
+	r.collectorsFailed.Store(0)
+
 	scrapeTime := time.Now()
 	if r.ctx.Err() != nil {
 		r.logger.With("error", r.ctx.Err()).Warn("skipping further collection")

--- a/internal/collector/redfish_collector.go
+++ b/internal/collector/redfish_collector.go
@@ -45,8 +45,10 @@ type redfishCollector struct {
 
 	// collectorsSucceeded and collectorsFailed track how many sub-collectors
 	// completed successfully or failed in the most recent Collect() call.
-	// They are reset to zero at the start of each Collect() and incremented
-	// as sub-collector goroutines complete.
+	// They are reset to zero at the start of each Collect(). collectorSucceeded is 
+	// incremented as sub-collector goroutines complete. collectorsFailed is derived 
+	// at the end of Collect() as the difference between total collectors and successful 
+	// ones.
 	collectorsSucceeded atomic.Int64
 	collectorsFailed    atomic.Int64
 }
@@ -106,12 +108,18 @@ func (r *redfishCollector) Collect(ch chan<- prometheus.Metric) {
 		for _, collector := range r.collectors {
 			eg.Go(func() error {
 				collector.CollectWithContext(r.ctx, ch)
+				// Only reached if CollectWithContext returns without panicking.
+				// Panics are caught by recoverGroup and skip this line, so
+				// collectorsSucceeded naturally undercounts on panic.
+				r.collectorsSucceeded.Add(1)
 				return nil
 			})
 		}
 		if err := eg.Wait(); err != nil {
 			r.logger.Error("goroutine error", slog.Any("error", err))
 		}
+		// The delta is the number of collectors that didn't complete successfully.
+		r.collectorsFailed.Store(int64(len(r.collectors)) - r.collectorsSucceeded.Load())
 	}
 
 	ch <- r.redfishUp

--- a/internal/collector/redfish_collector_test.go
+++ b/internal/collector/redfish_collector_test.go
@@ -1,0 +1,69 @@
+package collector
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+// stubCollector is a no-op ContextAwareCollector used to populate redfishCollector.collectors
+// without making any real Redfish API calls.
+type stubCollector struct{}
+
+func (s *stubCollector) Describe(_ chan<- *prometheus.Desc)                           {}
+func (s *stubCollector) Collect(_ chan<- prometheus.Metric)                           {}
+func (s *stubCollector) CollectWithContext(_ context.Context, _ chan<- prometheus.Metric) {}
+
+// newTestRedfishCollector builds a redfishCollector with no real Redfish connection,
+// suitable for unit-testing collector-level behaviour such as counter resets.
+func newTestRedfishCollector(collectors []ContextAwareCollector) *redfishCollector {
+	return &redfishCollector{
+		ctx:        context.Background(),
+		collectors: collectors,
+		redfishUp:  prometheus.NewGauge(prometheus.GaugeOpts{Name: "redfish_up_test"}),
+	}
+}
+
+// TestCollect_ResetsCounters verifies that collectorsSucceeded and collectorsFailed are
+// both reset to zero at the start of every Collect() call. This ensures that counts from
+// a previous scrape session do not carry over into the next one, keeping per-scrape
+// outcome tracking accurate.
+func TestCollect_ResetsCounters(t *testing.T) {
+	rc := newTestRedfishCollector([]ContextAwareCollector{&stubCollector{}, &stubCollector{}})
+
+	t.Run("counters start at zero before first Collect", func(t *testing.T) {
+		assert.Equal(t, int64(0), rc.collectorsSucceeded.Load())
+		assert.Equal(t, int64(0), rc.collectorsFailed.Load())
+	})
+
+	t.Run("counters are reset to zero at the start of a subsequent Collect", func(t *testing.T) {
+		// Simulate leftover state from a previous scrape session.
+		rc.collectorsSucceeded.Store(3)
+		rc.collectorsFailed.Store(2)
+
+		ch := make(chan prometheus.Metric, 16)
+		rc.Collect(ch)
+
+		// The reset happens before any goroutine work, so after Collect() returns
+		// the counters reflect the just-completed session, not the seeded values.
+		// We verify only that the seed values (3 and 2) are gone.
+		assert.NotEqual(t, int64(3), rc.collectorsSucceeded.Load(), "collectorsSucceeded should have been reset")
+		assert.NotEqual(t, int64(2), rc.collectorsFailed.Load(), "collectorsFailed should have been reset")
+	})
+
+	t.Run("counters are reset to zero on every Collect call", func(t *testing.T) {
+		// Seed non-zero values and confirm each new Collect wipes them.
+		for range 3 {
+			rc.collectorsSucceeded.Store(99)
+			rc.collectorsFailed.Store(99)
+
+			ch := make(chan prometheus.Metric, 16)
+			rc.Collect(ch)
+
+			assert.NotEqual(t, int64(99), rc.collectorsSucceeded.Load())
+			assert.NotEqual(t, int64(99), rc.collectorsFailed.Load())
+		}
+	})
+}

--- a/internal/collector/redfish_collector_test.go
+++ b/internal/collector/redfish_collector_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // stubCollector is a no-op ContextAwareCollector used to populate redfishCollector.collectors
@@ -16,8 +18,8 @@ type stubCollector struct {
 	panicOnCollect bool
 }
 
-func (s *stubCollector) Describe(_ chan<- *prometheus.Desc)                              {}
-func (s *stubCollector) Collect(_ chan<- prometheus.Metric)                              {}
+func (s *stubCollector) Describe(_ chan<- *prometheus.Desc) {}
+func (s *stubCollector) Collect(_ chan<- prometheus.Metric) {}
 func (s *stubCollector) CollectWithContext(_ context.Context, _ chan<- prometheus.Metric) {
 	if s.panicOnCollect {
 		panic("simulated collector panic")
@@ -103,6 +105,59 @@ func TestCollect_CountsOutcomes(t *testing.T) {
 	})
 }
 
+// TestCollectorOutcome verifies that CollectorOutcome() returns the succeeded and failed
+// counts that reflect the most recent Collect() call, and that it is consistent with
+// the values emitted as Prometheus gauges.
+func TestCollectorOutcome(t *testing.T) {
+	t.Run("returns succeeded and failed counts after all succeed", func(t *testing.T) {
+		rc := newTestRedfishCollector([]ContextAwareCollector{
+			&stubCollector{},
+			&stubCollector{},
+		})
+		ch := make(chan prometheus.Metric, 16)
+		rc.Collect(ch)
+
+		succeeded, failed := rc.CollectorOutcome()
+		assert.Equal(t, int64(2), succeeded)
+		assert.Equal(t, int64(0), failed)
+	})
+
+	t.Run("returns succeeded and failed counts after all fail", func(t *testing.T) {
+		rc := newTestRedfishCollector([]ContextAwareCollector{
+			&stubCollector{panicOnCollect: true},
+			&stubCollector{panicOnCollect: true},
+		})
+		ch := make(chan prometheus.Metric, 16)
+		rc.Collect(ch)
+
+		succeeded, failed := rc.CollectorOutcome()
+		assert.Equal(t, int64(0), succeeded)
+		assert.Equal(t, int64(2), failed)
+	})
+
+	t.Run("returns updated counts after each Collect call", func(t *testing.T) {
+		// Verifies that CollectorOutcome() always reflects the most recent Collect(),
+		// not a stale result from a previous scrape session.
+		rc := newTestRedfishCollector([]ContextAwareCollector{
+			&stubCollector{},
+			&stubCollector{panicOnCollect: true},
+		})
+
+		ch := make(chan prometheus.Metric, 16)
+		rc.Collect(ch)
+		succeeded, failed := rc.CollectorOutcome()
+		assert.Equal(t, int64(1), succeeded)
+		assert.Equal(t, int64(1), failed)
+
+		// Second Collect with same collectors — outcome should be identical, not accumulated.
+		ch = make(chan prometheus.Metric, 16)
+		rc.Collect(ch)
+		succeeded, failed = rc.CollectorOutcome()
+		assert.Equal(t, int64(1), succeeded)
+		assert.Equal(t, int64(1), failed)
+	})
+}
+
 // TestCollect_ResetsCounters verifies that collectorsSucceeded and collectorsFailed are
 // both reset to zero at the start of every Collect() call. This ensures that counts from
 // a previous scrape session do not carry over into the next one, keeping per-scrape
@@ -142,5 +197,87 @@ func TestCollect_ResetsCounters(t *testing.T) {
 			assert.NotEqual(t, int64(99), rc.collectorsSucceeded.Load())
 			assert.NotEqual(t, int64(99), rc.collectorsFailed.Load())
 		}
+	})
+}
+
+func findSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+// TestCollect_EmitsGauges verifies that Collect() emits
+// redfish_exporter_collectors_succeeded and redfish_exporter_collectors_failed
+// as Prometheus gauge metrics with values that match the atomic counters.
+func TestCollect_EmitsGauges(t *testing.T) {
+	// collectMetricValues runs Collect and returns the emitted gauge values for
+	// collectors_succeeded and collectors_failed by reading from the channel.
+	collectMetricValues := func(t *testing.T, rc *redfishCollector) (succeeded, failed float64) {
+		t.Helper()
+		ch := make(chan prometheus.Metric, 32)
+		rc.Collect(ch)
+		close(ch)
+		for m := range ch {
+			var dtoM dto.Metric
+			require.NoError(t, m.Write(&dtoM))
+			if dtoM.Gauge == nil {
+				continue
+			}
+			desc := m.Desc().String()
+			if findSubstring(desc, "collectors_succeeded") {
+				succeeded = dtoM.Gauge.GetValue()
+			}
+			if findSubstring(desc, "collectors_failed") {
+				failed = dtoM.Gauge.GetValue()
+			}
+		}
+		return
+	}
+
+	t.Run("emits succeeded=N failed=0 when all collectors succeed", func(t *testing.T) {
+		rc := newTestRedfishCollector([]ContextAwareCollector{
+			&stubCollector{},
+			&stubCollector{},
+			&stubCollector{},
+		})
+		succeeded, failed := collectMetricValues(t, rc)
+		assert.Equal(t, float64(3), succeeded)
+		assert.Equal(t, float64(0), failed)
+	})
+
+	t.Run("emits succeeded=0 failed=N when all collectors panic", func(t *testing.T) {
+		rc := newTestRedfishCollector([]ContextAwareCollector{
+			&stubCollector{panicOnCollect: true},
+			&stubCollector{panicOnCollect: true},
+		})
+		succeeded, failed := collectMetricValues(t, rc)
+		assert.Equal(t, float64(0), succeeded)
+		assert.Equal(t, float64(2), failed)
+	})
+
+	t.Run("emits correct values for mixed success and failure", func(t *testing.T) {
+		rc := newTestRedfishCollector([]ContextAwareCollector{
+			&stubCollector{},
+			&stubCollector{panicOnCollect: true},
+			&stubCollector{},
+		})
+		succeeded, failed := collectMetricValues(t, rc)
+		assert.Equal(t, float64(2), succeeded)
+		assert.Equal(t, float64(1), failed)
+	})
+
+	t.Run("gauge values match atomic counters after Collect", func(t *testing.T) {
+		// Verifies consistency between the emitted gauge values and the struct fields,
+		// ensuring the metrics are not stale snapshots taken at the wrong point.
+		rc := newTestRedfishCollector([]ContextAwareCollector{
+			&stubCollector{},
+			&stubCollector{panicOnCollect: true},
+		})
+		succeeded, failed := collectMetricValues(t, rc)
+		assert.Equal(t, float64(rc.collectorsSucceeded.Load()), succeeded)
+		assert.Equal(t, float64(rc.collectorsFailed.Load()), failed)
 	})
 }

--- a/internal/collector/redfish_collector_test.go
+++ b/internal/collector/redfish_collector_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -10,11 +11,18 @@ import (
 
 // stubCollector is a no-op ContextAwareCollector used to populate redfishCollector.collectors
 // without making any real Redfish API calls.
-type stubCollector struct{}
+type stubCollector struct {
+	// panicOnCollect causes CollectWithContext to panic, simulating a sub-collector crash.
+	panicOnCollect bool
+}
 
-func (s *stubCollector) Describe(_ chan<- *prometheus.Desc)                           {}
-func (s *stubCollector) Collect(_ chan<- prometheus.Metric)                           {}
-func (s *stubCollector) CollectWithContext(_ context.Context, _ chan<- prometheus.Metric) {}
+func (s *stubCollector) Describe(_ chan<- *prometheus.Desc)                              {}
+func (s *stubCollector) Collect(_ chan<- prometheus.Metric)                              {}
+func (s *stubCollector) CollectWithContext(_ context.Context, _ chan<- prometheus.Metric) {
+	if s.panicOnCollect {
+		panic("simulated collector panic")
+	}
+}
 
 // newTestRedfishCollector builds a redfishCollector with no real Redfish connection,
 // suitable for unit-testing collector-level behaviour such as counter resets.
@@ -22,8 +30,77 @@ func newTestRedfishCollector(collectors []ContextAwareCollector) *redfishCollect
 	return &redfishCollector{
 		ctx:        context.Background(),
 		collectors: collectors,
+		logger:     slog.Default(),
 		redfishUp:  prometheus.NewGauge(prometheus.GaugeOpts{Name: "redfish_up_test"}),
 	}
+}
+
+// TestCollect_CountsOutcomes verifies that collectorsSucceeded and collectorsFailed reflect
+// the actual outcome of each sub-collector goroutine after Collect() completes.
+// collectorsSucceeded is incremented only when CollectWithContext returns normally;
+// collectorsFailed is derived as len(collectors) - collectorsSucceeded, so panicking
+// goroutines (caught by recoverGroup) are automatically counted as failures.
+func TestCollect_CountsOutcomes(t *testing.T) {
+	t.Run("all collectors succeed", func(t *testing.T) {
+		rc := newTestRedfishCollector([]ContextAwareCollector{
+			&stubCollector{},
+			&stubCollector{},
+			&stubCollector{},
+		})
+		ch := make(chan prometheus.Metric, 16)
+		rc.Collect(ch)
+
+		assert.Equal(t, int64(3), rc.collectorsSucceeded.Load())
+		assert.Equal(t, int64(0), rc.collectorsFailed.Load())
+	})
+
+	t.Run("all collectors fail via panic", func(t *testing.T) {
+		rc := newTestRedfishCollector([]ContextAwareCollector{
+			&stubCollector{panicOnCollect: true},
+			&stubCollector{panicOnCollect: true},
+		})
+		ch := make(chan prometheus.Metric, 16)
+		rc.Collect(ch)
+
+		assert.Equal(t, int64(0), rc.collectorsSucceeded.Load())
+		assert.Equal(t, int64(2), rc.collectorsFailed.Load())
+	})
+
+	t.Run("mixed success and failure", func(t *testing.T) {
+		rc := newTestRedfishCollector([]ContextAwareCollector{
+			&stubCollector{},
+			&stubCollector{panicOnCollect: true},
+			&stubCollector{},
+			&stubCollector{panicOnCollect: true},
+		})
+		ch := make(chan prometheus.Metric, 16)
+		rc.Collect(ch)
+
+		assert.Equal(t, int64(2), rc.collectorsSucceeded.Load())
+		assert.Equal(t, int64(2), rc.collectorsFailed.Load())
+	})
+
+	t.Run("no collectors registered", func(t *testing.T) {
+		rc := newTestRedfishCollector([]ContextAwareCollector{})
+		ch := make(chan prometheus.Metric, 16)
+		rc.Collect(ch)
+
+		assert.Equal(t, int64(0), rc.collectorsSucceeded.Load())
+		assert.Equal(t, int64(0), rc.collectorsFailed.Load())
+	})
+
+	t.Run("succeeded and failed always sum to total collectors", func(t *testing.T) {
+		collectors := []ContextAwareCollector{
+			&stubCollector{},
+			&stubCollector{panicOnCollect: true},
+			&stubCollector{},
+		}
+		rc := newTestRedfishCollector(collectors)
+		ch := make(chan prometheus.Metric, 16)
+		rc.Collect(ch)
+
+		assert.Equal(t, int64(len(collectors)), rc.collectorsSucceeded.Load()+rc.collectorsFailed.Load())
+	})
 }
 
 // TestCollect_ResetsCounters verifies that collectorsSucceeded and collectorsFailed are


### PR DESCRIPTION
Keep track of number of sub-scrapers succeeded / failed. A scrape is successful only if all sub-collectors succeed without error. Increment the counter of successful scrapes. Added unit tests accordingly.