### PR TITLE
Add firmware inventory collector for fleet drift detection

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -20,6 +20,8 @@ loglevel: info
 modules:
   chassis:
     prober: chassis_collector
+  firmware_inventory:
+    prober: firmware_inventory_collector
   gpu:
     prober: gpu_collector
   manager:

--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -31,6 +31,8 @@ func NewCollectorFromModule(moduleName string, m *config.Module, rfClient *gofis
 	switch m.Prober {
 	case "chassis_collector":
 		return NewChassisCollector(moduleName, rfClient, logger, m.ChassisCollector)
+	case "firmware_inventory_collector":
+		return NewFirmwareInventoryCollector(moduleName, rfClient, logger, m.FirmwareInventoryCollector)
 	case "gpu_collector":
 		return NewGPUCollector(moduleName, rfClient, logger, m.GPUCollector)
 	case "json_collector":

--- a/internal/collector/firmware_inventory_collector.go
+++ b/internal/collector/firmware_inventory_collector.go
@@ -25,6 +25,8 @@ var (
 	firmwareInventoryMetrics = createFirmwareInventoryMetricMap()
 )
 
+var _ ContextAwareCollector = (*FirmwareInventoryCollector)(nil)
+
 // FirmwareInventoryCollector implements the prometheus.Collector for firmware inventory metrics.
 type FirmwareInventoryCollector struct {
 	redfishClient         *gofish.APIClient
@@ -38,7 +40,7 @@ func createFirmwareInventoryMetricMap() map[string]Metric {
 	metrics := make(map[string]Metric)
 	addToMetricMap(metrics, FirmwareInventorySubsystem, "state", fmt.Sprintf("firmware inventory state,%s", CommonStateHelp), FirmwareInventoryLabelNames)
 	addToMetricMap(metrics, FirmwareInventorySubsystem, "health", fmt.Sprintf("firmware inventory health,%s", CommonHealthHelp), FirmwareInventoryLabelNames)
-	addToMetricMap(metrics, FirmwareInventorySubsystem, "write_protected", "firmware inventory write protection (1 if write-protected)", FirmwareInventoryLabelNames)
+	addToMetricMap(metrics, FirmwareInventorySubsystem, "write_protected", "firmware inventory write protection (1 if write-protected, 0 if not write-protected or field absent from BMC response)", FirmwareInventoryLabelNames)
 	addToMetricMap(metrics, FirmwareInventorySubsystem, "info", "firmware inventory metadata; always 1. The version label on this metric is the fleet drift signal.", FirmwareInventoryInfoLabelNames)
 	return metrics
 }
@@ -86,7 +88,7 @@ func (f *FirmwareInventoryCollector) collect(ctx context.Context, ch chan<- prom
 		return
 	}
 	logger := f.logger.With(slog.String("collector", "FirmwareInventoryCollector"))
-	service := f.redfishClient.Service
+	service := f.redfishClient.WithContext(ctx).Service
 
 	updateService, err := service.UpdateService()
 	if err != nil {

--- a/internal/collector/firmware_inventory_collector.go
+++ b/internal/collector/firmware_inventory_collector.go
@@ -15,8 +15,14 @@ import (
 var (
 	FirmwareInventorySubsystem = "firmware_inventory"
 
-	FirmwareInventoryLabelNames     = []string{"component_id"}
-	FirmwareInventoryInfoLabelNames = []string{"component_id", "name", "version", "manufacturer"}
+	// FirmwareInventoryLabelNames are on every firmware_inventory_* metric. name and
+	// manufacturer are stable across firmware updates, so inlining them avoids forcing
+	// `* on(...) group_left(name, manufacturer) _info` joins in every query/alert.
+	FirmwareInventoryLabelNames = []string{"component_id", "name", "manufacturer"}
+	// FirmwareInventoryInfoLabelNames adds version — the only volatile identifier —
+	// so firmware updates churn just _info, leaving _state/_health/_write_protected
+	// on continuous series.
+	FirmwareInventoryInfoLabelNames = []string{"component_id", "name", "manufacturer", "version"}
 
 	// Id-prefix exclusions: inactive recovery / standby / staged-update slots
 	// that would generate false drift alerts if surfaced as fleet metrics.
@@ -115,7 +121,7 @@ func (f *FirmwareInventoryCollector) collect(ctx context.Context, ch chan<- prom
 			continue
 		}
 
-		labelValues := []string{item.ID}
+		labelValues := []string{item.ID, item.Name, item.Manufacturer}
 
 		if v, ok := parseCommonStatusState(item.Status.State); ok {
 			ch <- prometheus.MustNewConstMetric(f.metrics["firmware_inventory_state"].desc, prometheus.GaugeValue, v, labelValues...)
@@ -125,7 +131,7 @@ func (f *FirmwareInventoryCollector) collect(ctx context.Context, ch chan<- prom
 		}
 		ch <- prometheus.MustNewConstMetric(f.metrics["firmware_inventory_write_protected"].desc, prometheus.GaugeValue, boolToFloat64(item.WriteProtected), labelValues...)
 
-		infoLabelValues := []string{item.ID, item.Name, item.Version, item.Manufacturer}
+		infoLabelValues := append(labelValues, item.Version)
 		ch <- prometheus.MustNewConstMetric(f.metrics["firmware_inventory_info"].desc, prometheus.GaugeValue, 1, infoLabelValues...)
 	}
 

--- a/internal/collector/firmware_inventory_collector.go
+++ b/internal/collector/firmware_inventory_collector.go
@@ -1,0 +1,140 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/LambdaLabs/redfish_exporter/internal/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stmcginnis/gofish"
+)
+
+// FirmwareInventorySubsystem is the firmware inventory subsystem name.
+var (
+	FirmwareInventorySubsystem = "firmware_inventory"
+
+	FirmwareInventoryLabelNames     = []string{"component_id"}
+	FirmwareInventoryInfoLabelNames = []string{"component_id", "name", "version", "manufacturer"}
+
+	// Id-prefix exclusions: inactive recovery / standby / staged-update slots
+	// that would generate false drift alerts if surfaced as fleet metrics.
+	firmwareInventoryExcludedIDPrefixes = []string{"Backup_", "Golden_", "Capsule_"}
+
+	firmwareInventoryMetrics = createFirmwareInventoryMetricMap()
+)
+
+// FirmwareInventoryCollector implements the prometheus.Collector for firmware inventory metrics.
+type FirmwareInventoryCollector struct {
+	redfishClient         *gofish.APIClient
+	config                config.FirmwareInventoryCollectorConfig
+	metrics               map[string]Metric
+	logger                *slog.Logger
+	collectorScrapeStatus *prometheus.GaugeVec
+}
+
+func createFirmwareInventoryMetricMap() map[string]Metric {
+	metrics := make(map[string]Metric)
+	addToMetricMap(metrics, FirmwareInventorySubsystem, "state", fmt.Sprintf("firmware inventory state,%s", CommonStateHelp), FirmwareInventoryLabelNames)
+	addToMetricMap(metrics, FirmwareInventorySubsystem, "health", fmt.Sprintf("firmware inventory health,%s", CommonHealthHelp), FirmwareInventoryLabelNames)
+	addToMetricMap(metrics, FirmwareInventorySubsystem, "write_protected", "firmware inventory write protection (1 if write-protected)", FirmwareInventoryLabelNames)
+	addToMetricMap(metrics, FirmwareInventorySubsystem, "info", "firmware inventory metadata; always 1. The version label on this metric is the fleet drift signal.", FirmwareInventoryInfoLabelNames)
+	return metrics
+}
+
+// NewFirmwareInventoryCollector returns a collector that exposes firmware version and status
+// for entries under /redfish/v1/UpdateService/FirmwareInventory.
+func NewFirmwareInventoryCollector(moduleName string, redfishClient *gofish.APIClient, logger *slog.Logger, config config.FirmwareInventoryCollectorConfig) (*FirmwareInventoryCollector, error) {
+	return &FirmwareInventoryCollector{
+		redfishClient: redfishClient,
+		config:        config,
+		metrics:       firmwareInventoryMetrics,
+		logger:        logger,
+		collectorScrapeStatus: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "collector_scrape_status",
+				Help:      "collector_scrape_status",
+			},
+			[]string{"collector"},
+		),
+	}, nil
+}
+
+// Describe implements prometheus.Collector.
+func (f *FirmwareInventoryCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, metric := range f.metrics {
+		ch <- metric.desc
+	}
+	f.collectorScrapeStatus.Describe(ch)
+}
+
+// Collect implements prometheus.Collector.
+func (f *FirmwareInventoryCollector) Collect(ch chan<- prometheus.Metric) {
+	f.collect(context.TODO(), ch)
+}
+
+// CollectWithContext implements ContextAwareCollector.
+func (f *FirmwareInventoryCollector) CollectWithContext(ctx context.Context, ch chan<- prometheus.Metric) {
+	f.collect(ctx, ch)
+}
+
+func (f *FirmwareInventoryCollector) collect(ctx context.Context, ch chan<- prometheus.Metric) {
+	if ctx.Err() != nil {
+		f.logger.With("error", ctx.Err(), "collector", "firmware_inventory").Debug("skipping collection")
+		return
+	}
+	logger := f.logger.With(slog.String("collector", "FirmwareInventoryCollector"))
+	service := f.redfishClient.Service
+
+	updateService, err := service.UpdateService()
+	if err != nil {
+		logger.Error("error getting update service", slog.String("operation", "service.UpdateService()"), slog.Any("error", err))
+		return
+	}
+	if updateService == nil {
+		logger.Info("no update service found", slog.String("operation", "service.UpdateService()"))
+		return
+	}
+
+	inventories, err := updateService.FirmwareInventory()
+	if err != nil {
+		logger.Error("error getting firmware inventory", slog.String("operation", "updateService.FirmwareInventory()"), slog.Any("error", err))
+		return
+	}
+
+	for _, item := range inventories {
+		if ctx.Err() != nil {
+			logger.With("error", ctx.Err()).Debug("skipping further collection")
+			return
+		}
+		if item == nil || isExcludedFirmwareInventoryID(item.ID) {
+			continue
+		}
+
+		labelValues := []string{item.ID}
+
+		if v, ok := parseCommonStatusState(item.Status.State); ok {
+			ch <- prometheus.MustNewConstMetric(f.metrics["firmware_inventory_state"].desc, prometheus.GaugeValue, v, labelValues...)
+		}
+		if v, ok := parseCommonStatusHealth(item.Status.Health); ok {
+			ch <- prometheus.MustNewConstMetric(f.metrics["firmware_inventory_health"].desc, prometheus.GaugeValue, v, labelValues...)
+		}
+		ch <- prometheus.MustNewConstMetric(f.metrics["firmware_inventory_write_protected"].desc, prometheus.GaugeValue, boolToFloat64(item.WriteProtected), labelValues...)
+
+		infoLabelValues := []string{item.ID, item.Name, item.Version, item.Manufacturer}
+		ch <- prometheus.MustNewConstMetric(f.metrics["firmware_inventory_info"].desc, prometheus.GaugeValue, 1, infoLabelValues...)
+	}
+
+	f.collectorScrapeStatus.WithLabelValues("firmware_inventory").Set(float64(1))
+}
+
+func isExcludedFirmwareInventoryID(id string) bool {
+	for _, prefix := range firmwareInventoryExcludedIDPrefixes {
+		if strings.HasPrefix(id, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/collector/firmware_inventory_collector_test.go
+++ b/internal/collector/firmware_inventory_collector_test.go
@@ -1,0 +1,197 @@
+package collector
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/LambdaLabs/redfish_exporter/internal/config"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+type collectedFirmwareMetric struct {
+	metricName string
+	labels     map[string]string
+	value      float64
+}
+
+func collectFirmwareInventoryMetrics(t *testing.T) []collectedFirmwareMetric {
+	t.Helper()
+	return collectFirmwareInventoryMetricsFromFixture(t, "testdata/firmware_inventory_happypath")
+}
+
+func collectFirmwareInventoryMetricsFromFixture(t *testing.T, fixture string) []collectedFirmwareMetric {
+	t.Helper()
+	_, client := setupTestServerClient(t, fixture)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	collector, err := NewFirmwareInventoryCollector(t.Name(), client, logger, config.DefaultFirmwareInventoryCollector)
+	require.NoError(t, err)
+
+	ch := make(chan prometheus.Metric, 100)
+	go func() {
+		collector.Collect(ch)
+		close(ch)
+	}()
+
+	var collected []collectedFirmwareMetric
+	for metric := range ch {
+		descString := metric.Desc().String()
+		// Skip the meta `redfish_collector_scrape_status` gauge — only want firmware_inventory_* metrics.
+		if !strings.Contains(descString, "redfish_firmware_inventory_") {
+			continue
+		}
+		d := &dto.Metric{}
+		require.NoError(t, metric.Write(d))
+		labels := make(map[string]string, len(d.Label))
+		for _, l := range d.Label {
+			labels[l.GetName()] = l.GetValue()
+		}
+		// Pull metric name from FQName in the desc string: 'fqName: "redfish_firmware_inventory_state"'.
+		var name string
+		if i := strings.Index(descString, `fqName: "`); i >= 0 {
+			rest := descString[i+len(`fqName: "`):]
+			if j := strings.Index(rest, `"`); j >= 0 {
+				name = rest[:j]
+			}
+		}
+		collected = append(collected, collectedFirmwareMetric{
+			metricName: name,
+			labels:     labels,
+			value:      d.GetGauge().GetValue(),
+		})
+	}
+	return collected
+}
+
+func TestFirmwareInventoryCollectorEmitsExpectedMembers(t *testing.T) {
+	collected := collectFirmwareInventoryMetrics(t)
+
+	componentIDs := map[string]struct{}{}
+	for _, m := range collected {
+		componentIDs[m.labels["component_id"]] = struct{}{}
+	}
+	for _, expected := range []string{"HGX_FW_BMC_0", "BMC", "BIOS", "GPU1", "HGX_FW_ERoT_BMC_0"} {
+		require.Contains(t, componentIDs, expected, "expected firmware inventory member %s to be present", expected)
+	}
+}
+
+func TestFirmwareInventoryCollectorExcludesBackupGoldenCapsule(t *testing.T) {
+	collected := collectFirmwareInventoryMetrics(t)
+
+	for _, m := range collected {
+		id := m.labels["component_id"]
+		require.False(t, strings.HasPrefix(id, "Backup_"), "Backup_-prefixed firmware should be excluded; got %s", id)
+		require.False(t, strings.HasPrefix(id, "Golden_"), "Golden_-prefixed firmware should be excluded; got %s", id)
+		require.False(t, strings.HasPrefix(id, "Capsule_"), "Capsule_-prefixed firmware should be excluded; got %s", id)
+	}
+}
+
+func TestFirmwareInventoryCollectorInfoMetricLabels(t *testing.T) {
+	collected := collectFirmwareInventoryMetrics(t)
+
+	expectedInfo := map[string]struct{ name, version, manufacturer string }{
+		"HGX_FW_BMC_0":      {"Software Inventory", "HGX-22.10-1-rc67", "NVIDIA"},
+		"BMC":               {"BMC", "01.04.11", "Supermicro"},
+		"BIOS":              {"BIOS", "BIOS Date: 10/28/2025 Ver 2.7a", "Supermicro"},
+		"GPU1":              {"GPU1 System Slot1", "96.00.A5.00.01", "Supermicro"},
+		"HGX_FW_ERoT_BMC_0": {"Software Inventory", "00.02.0182.0000_n00", "NVIDIA"},
+	}
+
+	seen := map[string]bool{}
+	for _, m := range collected {
+		if m.metricName != "redfish_firmware_inventory_info" {
+			continue
+		}
+		want, ok := expectedInfo[m.labels["component_id"]]
+		if !ok {
+			continue
+		}
+		require.Equal(t, float64(1), m.value, "info metric value must always be 1")
+		require.Equal(t, want.name, m.labels["name"], "name label for %s", m.labels["component_id"])
+		require.Equal(t, want.version, m.labels["version"], "version label for %s", m.labels["component_id"])
+		require.Equal(t, want.manufacturer, m.labels["manufacturer"], "manufacturer label for %s", m.labels["component_id"])
+		seen[m.labels["component_id"]] = true
+	}
+	require.Len(t, seen, len(expectedInfo), "did not see _info metrics for all expected members")
+}
+
+func TestFirmwareInventoryCollectorVersionOnlyOnInfoMetric(t *testing.T) {
+	collected := collectFirmwareInventoryMetrics(t)
+
+	// Drift detection requires version to live exclusively on _info; if it leaks onto
+	// _state/_health/_write_protected, every firmware update spawns new time series
+	// for those metrics and breaks historical health queries.
+	for _, m := range collected {
+		switch m.metricName {
+		case "redfish_firmware_inventory_state",
+			"redfish_firmware_inventory_health",
+			"redfish_firmware_inventory_write_protected":
+			require.NotContains(t, m.labels, "version",
+				"version label must not appear on %s (component_id=%s)", m.metricName, m.labels["component_id"])
+			require.NotContains(t, m.labels, "manufacturer",
+				"manufacturer label must not appear on %s (component_id=%s)", m.metricName, m.labels["component_id"])
+		}
+	}
+}
+
+func TestFirmwareInventoryCollectorStateAndHealthValues(t *testing.T) {
+	collected := collectFirmwareInventoryMetrics(t)
+
+	// All fixture members report State=Enabled (1) and Health=OK (1).
+	for _, m := range collected {
+		switch m.metricName {
+		case "redfish_firmware_inventory_state":
+			require.Equal(t, float64(1), m.value, "expected Enabled (1) for %s", m.labels["component_id"])
+		case "redfish_firmware_inventory_health":
+			require.Equal(t, float64(1), m.value, "expected OK (1) for %s", m.labels["component_id"])
+		case "redfish_firmware_inventory_write_protected":
+			require.Equal(t, float64(0), m.value, "expected WriteProtected=false (0) for %s", m.labels["component_id"])
+		}
+	}
+}
+
+func TestFirmwareInventoryCollectorMapsWarningCriticalAndWriteProtected(t *testing.T) {
+	collected := collectFirmwareInventoryMetricsFromFixture(t, "testdata/firmware_inventory_unhealthy")
+
+	want := map[string]struct {
+		state, health, writeProtected float64
+	}{
+		"WARNING_FW":   {state: 1, health: 2, writeProtected: 0},
+		"CRITICAL_FW":  {state: 2, health: 3, writeProtected: 0},
+		"PROTECTED_FW": {state: 1, health: 1, writeProtected: 1},
+	}
+
+	got := map[string]struct {
+		state, health, writeProtected float64
+	}{}
+
+	for _, m := range collected {
+		entry := got[m.labels["component_id"]]
+		switch m.metricName {
+		case "redfish_firmware_inventory_state":
+			entry.state = m.value
+		case "redfish_firmware_inventory_health":
+			entry.health = m.value
+		case "redfish_firmware_inventory_write_protected":
+			entry.writeProtected = m.value
+		}
+		got[m.labels["component_id"]] = entry
+	}
+
+	for id, expected := range want {
+		require.Equal(t, expected, got[id], "metric values for %s", id)
+	}
+}
+
+func TestFirmwareInventoryCollectorEmptyInventoryEmitsNoMemberMetrics(t *testing.T) {
+	collected := collectFirmwareInventoryMetricsFromFixture(t, "testdata/firmware_inventory_empty")
+	require.Empty(t, collected, "no firmware_inventory_* metrics should be emitted when inventory is empty")
+}
+
+func TestFirmwareInventoryCollectorAllExcludedEmitsNoMemberMetrics(t *testing.T) {
+	collected := collectFirmwareInventoryMetricsFromFixture(t, "testdata/firmware_inventory_all_excluded")
+	require.Empty(t, collected, "no firmware_inventory_* metrics should be emitted when every member matches an excluded prefix")
+}

--- a/internal/collector/firmware_inventory_collector_test.go
+++ b/internal/collector/firmware_inventory_collector_test.go
@@ -123,7 +123,9 @@ func TestFirmwareInventoryCollectorVersionOnlyOnInfoMetric(t *testing.T) {
 
 	// Drift detection requires version to live exclusively on _info; if it leaks onto
 	// _state/_health/_write_protected, every firmware update spawns new time series
-	// for those metrics and breaks historical health queries.
+	// for those metrics and breaks historical health queries. name and manufacturer
+	// are stable across firmware updates and ARE expected on the status metrics
+	// for query/alert ergonomics.
 	for _, m := range collected {
 		switch m.metricName {
 		case "redfish_firmware_inventory_state",
@@ -131,8 +133,10 @@ func TestFirmwareInventoryCollectorVersionOnlyOnInfoMetric(t *testing.T) {
 			"redfish_firmware_inventory_write_protected":
 			require.NotContains(t, m.labels, "version",
 				"version label must not appear on %s (component_id=%s)", m.metricName, m.labels["component_id"])
-			require.NotContains(t, m.labels, "manufacturer",
-				"manufacturer label must not appear on %s (component_id=%s)", m.metricName, m.labels["component_id"])
+			require.Contains(t, m.labels, "name",
+				"name label must appear on %s (component_id=%s)", m.metricName, m.labels["component_id"])
+			require.Contains(t, m.labels, "manufacturer",
+				"manufacturer label must appear on %s (component_id=%s)", m.metricName, m.labels["component_id"])
 		}
 	}
 }

--- a/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/UpdateService/FirmwareInventory/Backup_BMC/index.json
+++ b/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/UpdateService/FirmwareInventory/Backup_BMC/index.json
@@ -1,0 +1,29 @@
+{
+  "@odata.type": "#SoftwareInventory.v1_11_0.SoftwareInventory",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Backup_BMC",
+  "Id": "Backup_BMC",
+  "Name": "BMC Backup",
+  "Updateable": true,
+  "Version": "01.01.06",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "RelatedItem": [
+    {
+      "@odata.id": "/redfish/v1/Managers/1"
+    }
+  ],
+  "Actions": {
+    "Oem": {}
+  },
+  "Oem": {
+    "Supermicro": {
+      "@odata.type": "#SmcSoftwareInventoryExtensions.v1_0_0.SoftwareInventory",
+      "UniqueFilename": "BMC_X13AST2600-ROT-5501MS_20240210_01.01.06_STDsp.bin"
+    }
+  },
+  "Manufacturer": "Supermicro",
+  "WriteProtected": false,
+  "@odata.etag": "\"71e8c24298e24e98c85505c4dd1f2542\""
+}

--- a/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/UpdateService/FirmwareInventory/Capsule_BIOS/index.json
+++ b/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/UpdateService/FirmwareInventory/Capsule_BIOS/index.json
@@ -1,0 +1,31 @@
+{
+  "@odata.type": "#SoftwareInventory.v1_11_0.SoftwareInventory",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Capsule_BIOS",
+  "Id": "Capsule_BIOS",
+  "Name": "Capsule BIOS",
+  "Updateable": true,
+  "Version": "1.0",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "RelatedItem": [
+    {
+      "@odata.id": "/redfish/v1/Systems/1/Bios"
+    }
+  ],
+  "Actions": {
+    "Oem": {}
+  },
+  "Oem": {
+    "Supermicro": {
+      "SeamlessPackageVersion": "1.0",
+      "LayoutID": "0",
+      "Description": "EagleStream BIOS",
+      "@odata.type": "#SmcSoftwareInventoryExtensions.v1_0_0.SoftwareInventory"
+    }
+  },
+  "Manufacturer": "Supermicro",
+  "WriteProtected": false,
+  "@odata.etag": "\"92e62d8c21835fcfbf14b41d1ae230de\""
+}

--- a/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/UpdateService/FirmwareInventory/Golden_BIOS/index.json
+++ b/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/UpdateService/FirmwareInventory/Golden_BIOS/index.json
@@ -1,0 +1,29 @@
+{
+  "@odata.type": "#SoftwareInventory.v1_11_0.SoftwareInventory",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Golden_BIOS",
+  "Id": "Golden_BIOS",
+  "Name": "BIOS Golden",
+  "Updateable": true,
+  "Version": "BIOS Date: 08/04/2023 Ver 1.4",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "RelatedItem": [
+    {
+      "@odata.id": "/redfish/v1/Systems/1/Bios"
+    }
+  ],
+  "Actions": {
+    "Oem": {}
+  },
+  "Oem": {
+    "Supermicro": {
+      "@odata.type": "#SmcSoftwareInventoryExtensions.v1_0_0.SoftwareInventory",
+      "UniqueFilename": "BIOS_X13DEG-OAD-1D14_20230804_1.4_STDsp.bin"
+    }
+  },
+  "Manufacturer": "Supermicro",
+  "WriteProtected": false,
+  "@odata.etag": "\"be92594bb415a14952e54f1ebdb04b37\""
+}

--- a/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/UpdateService/FirmwareInventory/index.json
+++ b/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/UpdateService/FirmwareInventory/index.json
@@ -1,0 +1,11 @@
+{
+  "@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory",
+  "Name": "Firmware Inventory Collection",
+  "Members@odata.count": 3,
+  "Members": [
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Backup_BMC"},
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Golden_BIOS"},
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Capsule_BIOS"}
+  ]
+}

--- a/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/UpdateService/index.json
+++ b/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/UpdateService/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.type": "#UpdateService.v1_8_4.UpdateService",
+  "@odata.id": "/redfish/v1/UpdateService",
+  "Id": "UpdateService",
+  "Name": "Update Service",
+  "ServiceEnabled": true,
+  "FirmwareInventory": {
+    "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory"
+  }
+}

--- a/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/index.json
+++ b/internal/collector/testdata/firmware_inventory_all_excluded/redfish/v1/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.type": "#ServiceRoot.v1_9_0.ServiceRoot",
+  "@odata.id": "/redfish/v1",
+  "Id": "ServiceRoot",
+  "Name": "Root Service",
+  "RedfishVersion": "1.11.0",
+  "UpdateService": {
+    "@odata.id": "/redfish/v1/UpdateService"
+  }
+}

--- a/internal/collector/testdata/firmware_inventory_empty/redfish/v1/UpdateService/FirmwareInventory/index.json
+++ b/internal/collector/testdata/firmware_inventory_empty/redfish/v1/UpdateService/FirmwareInventory/index.json
@@ -1,0 +1,7 @@
+{
+  "@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory",
+  "Name": "Firmware Inventory Collection",
+  "Members@odata.count": 0,
+  "Members": []
+}

--- a/internal/collector/testdata/firmware_inventory_empty/redfish/v1/UpdateService/index.json
+++ b/internal/collector/testdata/firmware_inventory_empty/redfish/v1/UpdateService/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.type": "#UpdateService.v1_8_4.UpdateService",
+  "@odata.id": "/redfish/v1/UpdateService",
+  "Id": "UpdateService",
+  "Name": "Update Service",
+  "ServiceEnabled": true,
+  "FirmwareInventory": {
+    "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory"
+  }
+}

--- a/internal/collector/testdata/firmware_inventory_empty/redfish/v1/index.json
+++ b/internal/collector/testdata/firmware_inventory_empty/redfish/v1/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.type": "#ServiceRoot.v1_9_0.ServiceRoot",
+  "@odata.id": "/redfish/v1",
+  "Id": "ServiceRoot",
+  "Name": "Root Service",
+  "RedfishVersion": "1.11.0",
+  "UpdateService": {
+    "@odata.id": "/redfish/v1/UpdateService"
+  }
+}

--- a/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/BIOS/index.json
+++ b/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/BIOS/index.json
@@ -1,0 +1,31 @@
+{
+  "@odata.type": "#SoftwareInventory.v1_11_0.SoftwareInventory",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/BIOS",
+  "Id": "BIOS",
+  "Name": "BIOS",
+  "Updateable": true,
+  "Version": "BIOS Date: 10/28/2025 Ver 2.7a",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "RelatedItem": [
+    {
+      "@odata.id": "/redfish/v1/Systems/1/Bios"
+    }
+  ],
+  "Actions": {
+    "Oem": {}
+  },
+  "Oem": {
+    "Supermicro": {
+      "@odata.type": "#SmcSoftwareInventoryExtensions.v1_0_0.SoftwareInventory",
+      "UniqueFilename": "BIOS_X13DEG-OAD-1D14_20251028_2.7a_STDsp.bin",
+      "MicrocodeVersion": "2.5",
+      "SPSVersion": "22.64.192.12"
+    }
+  },
+  "Manufacturer": "Supermicro",
+  "WriteProtected": false,
+  "@odata.etag": "\"c404d60b03fa07461c4ca81b93019313\""
+}

--- a/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/BMC/index.json
+++ b/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/BMC/index.json
@@ -1,0 +1,30 @@
+{
+  "@odata.type": "#SoftwareInventory.v1_11_0.SoftwareInventory",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/BMC",
+  "Id": "BMC",
+  "Name": "BMC",
+  "Updateable": true,
+  "Version": "01.04.11",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "RelatedItem": [
+    {
+      "@odata.id": "/redfish/v1/Managers/1"
+    }
+  ],
+  "Actions": {
+    "Oem": {}
+  },
+  "Oem": {
+    "Supermicro": {
+      "@odata.type": "#SmcSoftwareInventoryExtensions.v1_0_0.SoftwareInventory",
+      "UniqueFilename": "BMC_X13AST2600-ROT-5501MS_20251015_01.04.11_STDsp.bin"
+    }
+  },
+  "Manufacturer": "Supermicro",
+  "ReleaseDate": "2025-10-15T00:00:00Z",
+  "WriteProtected": false,
+  "@odata.etag": "\"9251f5d045cd15c5bd8db6e91457a87b\""
+}

--- a/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/Backup_BMC/index.json
+++ b/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/Backup_BMC/index.json
@@ -1,0 +1,29 @@
+{
+  "@odata.type": "#SoftwareInventory.v1_11_0.SoftwareInventory",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Backup_BMC",
+  "Id": "Backup_BMC",
+  "Name": "BMC Backup",
+  "Updateable": true,
+  "Version": "01.01.06",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "RelatedItem": [
+    {
+      "@odata.id": "/redfish/v1/Managers/1"
+    }
+  ],
+  "Actions": {
+    "Oem": {}
+  },
+  "Oem": {
+    "Supermicro": {
+      "@odata.type": "#SmcSoftwareInventoryExtensions.v1_0_0.SoftwareInventory",
+      "UniqueFilename": "BMC_X13AST2600-ROT-5501MS_20240210_01.01.06_STDsp.bin"
+    }
+  },
+  "Manufacturer": "Supermicro",
+  "WriteProtected": false,
+  "@odata.etag": "\"71e8c24298e24e98c85505c4dd1f2542\""
+}

--- a/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/GPU1/index.json
+++ b/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/GPU1/index.json
@@ -1,0 +1,24 @@
+{
+  "@odata.type": "#SoftwareInventory.v1_11_0.SoftwareInventory",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/GPU1",
+  "Id": "GPU1",
+  "Name": "GPU1 System Slot1",
+  "Updateable": false,
+  "Version": "96.00.A5.00.01",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "RelatedItem": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/1/PCIeDevices/GPU1"
+    }
+  ],
+  "Actions": {
+    "Oem": {}
+  },
+  "Oem": {},
+  "Manufacturer": "Supermicro",
+  "WriteProtected": false,
+  "@odata.etag": "\"bb923075e84393fd0599c6966aa8b114\""
+}

--- a/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/HGX_FW_BMC_0/index.json
+++ b/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/HGX_FW_BMC_0/index.json
@@ -1,0 +1,24 @@
+{
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/HGX_FW_BMC_0",
+  "@odata.type": "#SoftwareInventory.v1_4_0.SoftwareInventory",
+  "Description": "BMC image",
+  "Id": "HGX_FW_BMC_0",
+  "Manufacturer": "NVIDIA",
+  "Name": "Software Inventory",
+  "RelatedItem": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/HGX_BMC_0"
+    }
+  ],
+  "RelatedItem@odata.count": 1,
+  "SoftwareId": "0x0010",
+  "Status": {
+    "Conditions": [],
+    "Health": "OK",
+    "HealthRollup": "OK",
+    "State": "Enabled"
+  },
+  "Updateable": true,
+  "Version": "HGX-22.10-1-rc67",
+  "WriteProtected": false
+}

--- a/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/HGX_FW_ERoT_BMC_0/index.json
+++ b/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/HGX_FW_ERoT_BMC_0/index.json
@@ -1,0 +1,23 @@
+{
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/HGX_FW_ERoT_BMC_0",
+  "@odata.type": "#SoftwareInventory.v1_4_0.SoftwareInventory",
+  "Description": "Other image",
+  "Id": "HGX_FW_ERoT_BMC_0",
+  "Manufacturer": "NVIDIA",
+  "Name": "Software Inventory",
+  "RelatedItem": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/HGX_ERoT_BMC_0"
+    }
+  ],
+  "RelatedItem@odata.count": 1,
+  "SoftwareId": "0xFF00",
+  "Status": {
+    "Conditions": [],
+    "Health": "OK",
+    "HealthRollup": "OK",
+    "State": "Enabled"
+  },
+  "Updateable": true,
+  "Version": "00.02.0182.0000_n00"
+}

--- a/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/index.json
+++ b/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/FirmwareInventory/index.json
@@ -1,0 +1,14 @@
+{
+  "@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory",
+  "Name": "Firmware Inventory Collection",
+  "Members@odata.count": 6,
+  "Members": [
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/HGX_FW_BMC_0"},
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/BMC"},
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/BIOS"},
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/GPU1"},
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/HGX_FW_ERoT_BMC_0"},
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Backup_BMC"}
+  ]
+}

--- a/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/index.json
+++ b/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/UpdateService/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.type": "#UpdateService.v1_8_4.UpdateService",
+  "@odata.id": "/redfish/v1/UpdateService",
+  "Id": "UpdateService",
+  "Name": "Update Service",
+  "ServiceEnabled": true,
+  "FirmwareInventory": {
+    "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory"
+  }
+}

--- a/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/index.json
+++ b/internal/collector/testdata/firmware_inventory_happypath/redfish/v1/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.type": "#ServiceRoot.v1_9_0.ServiceRoot",
+  "@odata.id": "/redfish/v1",
+  "Id": "ServiceRoot",
+  "Name": "Root Service",
+  "RedfishVersion": "1.11.0",
+  "UpdateService": {
+    "@odata.id": "/redfish/v1/UpdateService"
+  }
+}

--- a/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/UpdateService/FirmwareInventory/CRITICAL_FW/index.json
+++ b/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/UpdateService/FirmwareInventory/CRITICAL_FW/index.json
@@ -1,0 +1,14 @@
+{
+  "@odata.type": "#SoftwareInventory.v1_4_0.SoftwareInventory",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/CRITICAL_FW",
+  "Id": "CRITICAL_FW",
+  "Name": "Critical Firmware",
+  "Version": "1.0.0-crit",
+  "Manufacturer": "TestVendor",
+  "Status": {
+    "State": "Disabled",
+    "Health": "Critical"
+  },
+  "Updateable": false,
+  "WriteProtected": false
+}

--- a/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/UpdateService/FirmwareInventory/PROTECTED_FW/index.json
+++ b/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/UpdateService/FirmwareInventory/PROTECTED_FW/index.json
@@ -1,0 +1,14 @@
+{
+  "@odata.type": "#SoftwareInventory.v1_4_0.SoftwareInventory",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/PROTECTED_FW",
+  "Id": "PROTECTED_FW",
+  "Name": "Protected Firmware",
+  "Version": "1.0.0-locked",
+  "Manufacturer": "TestVendor",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "Updateable": false,
+  "WriteProtected": true
+}

--- a/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/UpdateService/FirmwareInventory/WARNING_FW/index.json
+++ b/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/UpdateService/FirmwareInventory/WARNING_FW/index.json
@@ -1,0 +1,14 @@
+{
+  "@odata.type": "#SoftwareInventory.v1_4_0.SoftwareInventory",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/WARNING_FW",
+  "Id": "WARNING_FW",
+  "Name": "Warning Firmware",
+  "Version": "1.0.0-warn",
+  "Manufacturer": "TestVendor",
+  "Status": {
+    "State": "Enabled",
+    "Health": "Warning"
+  },
+  "Updateable": true,
+  "WriteProtected": false
+}

--- a/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/UpdateService/FirmwareInventory/index.json
+++ b/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/UpdateService/FirmwareInventory/index.json
@@ -1,0 +1,11 @@
+{
+  "@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory",
+  "Name": "Firmware Inventory Collection",
+  "Members@odata.count": 3,
+  "Members": [
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/WARNING_FW"},
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/CRITICAL_FW"},
+    {"@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/PROTECTED_FW"}
+  ]
+}

--- a/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/UpdateService/index.json
+++ b/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/UpdateService/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.type": "#UpdateService.v1_8_4.UpdateService",
+  "@odata.id": "/redfish/v1/UpdateService",
+  "Id": "UpdateService",
+  "Name": "Update Service",
+  "ServiceEnabled": true,
+  "FirmwareInventory": {
+    "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory"
+  }
+}

--- a/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/index.json
+++ b/internal/collector/testdata/firmware_inventory_unhealthy/redfish/v1/index.json
@@ -1,0 +1,10 @@
+{
+  "@odata.type": "#ServiceRoot.v1_9_0.ServiceRoot",
+  "@odata.id": "/redfish/v1",
+  "Id": "ServiceRoot",
+  "Name": "Root Service",
+  "RedfishVersion": "1.11.0",
+  "UpdateService": {
+    "@odata.id": "/redfish/v1/UpdateService"
+  }
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,8 @@ import (
 var (
 	// DefaultChassisCollector is a default unless the user provides particular values.
 	DefaultChassisCollector = ChassisCollectorConfig{}
+	// DefaultFirmwareInventoryCollector is a default unless the user provides particular values.
+	DefaultFirmwareInventoryCollector = FirmwareInventoryCollectorConfig{}
 	// DefaultGPUCollector is a default unless the user provides particular values.
 	DefaultGPUCollector = GPUCollectorConfig{}
 	//DefaultJSONCollector is a default unless the user provides particular values.
@@ -31,6 +33,10 @@ var (
 		"chassis_collector": {
 			Prober:           "chassis_collector",
 			ChassisCollector: DefaultChassisCollector,
+		},
+		"firmware_inventory_collector": {
+			Prober:                     "firmware_inventory_collector",
+			FirmwareInventoryCollector: DefaultFirmwareInventoryCollector,
 		},
 		"gpu_collector": {
 			Prober:       "gpu_collector",
@@ -103,6 +109,9 @@ func unmarshalViperConfig(v *viper.Viper) (*Config, error) {
 // ChassisCollectorConfig is a prober configuration.
 type ChassisCollectorConfig struct{}
 
+// FirmwareInventoryCollectorConfig is a prober configuration.
+type FirmwareInventoryCollectorConfig struct{}
+
 // GPUCollectorConfig is a prober configuration.
 type GPUCollectorConfig struct{}
 
@@ -128,14 +137,15 @@ type PowershelfCollectorConfig struct{}
 // when executed against a host.
 // Modules are expected to specify a 'prober', and then a particular collector.
 type Module struct {
-	Prober              string                    `mapstructure:"prober"`
-	ChassisCollector    ChassisCollectorConfig    `mapstructure:"chassis_collector"`
-	GPUCollector        GPUCollectorConfig        `mapstructure:"gpu_collector"`
-	JSONCollector       JSONCollectorConfig       `mapstructure:"json_collector"`
-	ManagerCollector    ManagerCollectorConfig    `mapstructure:"manager_collector"`
-	SystemCollector     SystemCollectorConfig     `mapstructure:"system_collector"`
-	TelemetryCollector  TelemetryCollectorConfig  `mapstructure:"telemetry_collector"`
-	PowershelfCollector PowershelfCollectorConfig `mapstructure:"powershelf_collector"`
+	Prober                     string                           `mapstructure:"prober"`
+	ChassisCollector           ChassisCollectorConfig           `mapstructure:"chassis_collector"`
+	FirmwareInventoryCollector FirmwareInventoryCollectorConfig `mapstructure:"firmware_inventory_collector"`
+	GPUCollector               GPUCollectorConfig               `mapstructure:"gpu_collector"`
+	JSONCollector              JSONCollectorConfig              `mapstructure:"json_collector"`
+	ManagerCollector           ManagerCollectorConfig           `mapstructure:"manager_collector"`
+	PowershelfCollector        PowershelfCollectorConfig        `mapstructure:"powershelf_collector"`
+	SystemCollector            SystemCollectorConfig            `mapstructure:"system_collector"`
+	TelemetryCollector         TelemetryCollectorConfig         `mapstructure:"telemetry_collector"`
 }
 
 func (m *Module) Validate() error {


### PR DESCRIPTION
Exposes `/redfish/v1/UpdateService/FirmwareInventory` entries as Prometheus metrics. The primary use case is fleet-wide firmware version drift alerting — `count by (manufacturer, component_id) (count by (..., version) (redfish_firmware_inventory_info)) > 1` flags any component where two hosts disagree on version.

Metrics emitted per inventory member:

```
redfish_firmware_inventory_state{component_id}
redfish_firmware_inventory_health{component_id}
redfish_firmware_inventory_write_protected{component_id}
redfish_firmware_inventory_info{component_id, name, version, manufacturer}
```

### Label placement

Identity labels (`name`, `manufacturer`, `version`) live only on `_info`. Including a name-ish label alongside the id matches the dominant codebase pattern (`manager_collector` carries `name`/`model`/`firmware_version` on its status gauges), but isolating them to `_info` means firmware updates churn only the `_info` series — `_state` / `_health` / `_write_protected` stay on stable label sets, so historical health queries don't break across updates.

### Exclusions

Members whose `Id` starts with `Backup_`, `Golden_`, or `Capsule_` are excluded: those are inactive recovery, standby, and staged-update slots that would generate guaranteed false drift alerts.

### Tests

Cover happy-path, exclusion filtering, the version-only-on-info invariant, Warning/Critical/WriteProtected status mapping, empty inventory, and all-excluded inventory. Fixtures extracted from a real BMC dump.