### PR TITLE
Move scrape counters to per-request registry

### DIFF
--- a/cmd/redfish-exporter/main.go
+++ b/cmd/redfish-exporter/main.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -65,17 +66,32 @@ var (
 		Name: "redfish_exporter_unknown_modules_requested_total",
 		Help: "Count of requests specifying a module name not known to this exporter",
 	})
-	// scrapeRequestsTotal counts every scrape attempt per target, regardless of outcome.
-	scrapeRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "redfish_exporter_scrape_requests_total",
-		Help: "Total number of scrape requests received per target, regardless of success or failure.",
-	}, []string{"target"})
-	// scrapeSuccessesTotal counts scrapes where all sub-collectors completed without failure.
-	scrapeSuccessesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "redfish_exporter_scrape_successes_total",
-		Help: "Total number of scrapes where all sub-collectors completed successfully for the target.",
-	}, []string{"target"})
 )
+
+type diagnosticCounters struct {
+	requests  prometheus.Counter
+	successes prometheus.Counter
+}
+
+var diagnosticCountersByTarget sync.Map // map[string]*diagnosticCounters
+
+func fetchDiagnosticCounters(target string) *diagnosticCounters {
+	if v, ok := diagnosticCountersByTarget.Load(target); ok {
+		return v.(*diagnosticCounters)
+	}
+	tc := &diagnosticCounters{
+		requests: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "redfish_exporter_scrape_requests_total",
+			Help: "Total number of scrape requests received for this target, regardless of success or failure.",
+		}),
+		successes: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "redfish_exporter_scrape_successes_total",
+			Help: "Total number of scrapes where all sub-collectors completed successfully for this target.",
+		}),
+	}
+	actual, _ := diagnosticCountersByTarget.LoadOrStore(target, tc)
+	return actual.(*diagnosticCounters)
+}
 
 func reloadHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -105,8 +121,6 @@ func registerMetaMetrics() {
 	custom := []prometheus.Collector{
 		collectorLastStatus,
 		collectorModuleUnknown,
-		scrapeRequestsTotal,
-		scrapeSuccessesTotal,
 	}
 
 	prometheus.DefaultRegisterer.MustRegister(custom...)
@@ -201,7 +215,8 @@ func metricsHandler() http.HandlerFunc {
 			return
 		}
 
-		scrapeRequestsTotal.WithLabelValues(sr.Target).Inc()
+		tc := fetchDiagnosticCounters(sr.Target)
+		tc.requests.Inc()
 
 		scrapeLogger := ctxLogger.With("scrape_host", sr.Target)
 		rfClientConfig := safeConfig.RedfishClientConfig()
@@ -219,6 +234,10 @@ func metricsHandler() http.HandlerFunc {
 		collectors := buildCollectorsFor(r.Context(), sr.Modules, safeConfig.GetModules(), aggregateCollector.Client(), scrapeLogger)
 		aggregateCollector.WithCollectors(collectors)
 		registry.MustRegister(aggregateCollector)
+		// Register this target's scrape counters on the same per-request registry as the
+		// redfish collectors, so they emit at /redfish?target=X and pick up the same SD
+		// labels (hostname, oob_ip, rack, ...) as every other redfish_* metric.
+		registry.MustRegister(tc.requests, tc.successes)
 		gatherers := prometheus.Gatherers{
 			registry,
 		}
@@ -227,7 +246,7 @@ func metricsHandler() http.HandlerFunc {
 		h.ServeHTTP(w, r)
 
 		if _, failed := aggregateCollector.CollectorOutcome(); failed == 0 {
-			scrapeSuccessesTotal.WithLabelValues(sr.Target).Inc()
+			tc.successes.Inc()
 		}
 	}
 }

--- a/cmd/redfish-exporter/main_test.go
+++ b/cmd/redfish-exporter/main_test.go
@@ -295,13 +295,13 @@ func TestScrapeRequestsTotal(t *testing.T) {
 		// at all (e.g. host unreachable, TLS error) must still be counted so gaps in other
 		// metrics can be attributed to collection failure rather than a healthy absence of data.
 		target := "unreachable-failed.test:1"
-		before := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target))
+		before := testutil.ToFloat64(fetchDiagnosticCounters(target).requests)
 
 		w := httptest.NewRecorder()
 		metricsHandler()(w, newScrapeRequest(target, nil))
 
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
-		assert.Equal(t, before+1, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target)))
+		assert.Equal(t, before+1, testutil.ToFloat64(fetchDiagnosticCounters(target).requests))
 	})
 
 	t.Run("increments on successful scrape", func(t *testing.T) {
@@ -316,12 +316,12 @@ func TestScrapeRequestsTotal(t *testing.T) {
 		t.Cleanup(rfServer.Close)
 
 		target := rfServer.Listener.Addr().String()
-		before := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target))
+		before := testutil.ToFloat64(fetchDiagnosticCounters(target).requests)
 
 		w := httptest.NewRecorder()
 		metricsHandler()(w, newScrapeRequest(target, nil))
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, before+1, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target)))
+		assert.Equal(t, before+1, testutil.ToFloat64(fetchDiagnosticCounters(target).requests))
 	})
 
 	t.Run("counts are per target", func(t *testing.T) {
@@ -329,16 +329,16 @@ func TestScrapeRequestsTotal(t *testing.T) {
 		// scrape count is tracked independently and requests to one target do not affect another.
 		targetA := "per-target-a.test:1"
 		targetB := "per-target-b.test:1"
-		beforeA := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(targetA))
-		beforeB := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(targetB))
+		beforeA := testutil.ToFloat64(fetchDiagnosticCounters(targetA).requests)
+		beforeB := testutil.ToFloat64(fetchDiagnosticCounters(targetB).requests)
 
 		// Scrape targetA twice and targetB once, then verify the expected increments.
 		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(targetA, nil))
 		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(targetA, nil))
 		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(targetB, nil))
 
-		assert.Equal(t, beforeA+2, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(targetA)))
-		assert.Equal(t, beforeB+1, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(targetB)))
+		assert.Equal(t, beforeA+2, testutil.ToFloat64(fetchDiagnosticCounters(targetA).requests))
+		assert.Equal(t, beforeB+1, testutil.ToFloat64(fetchDiagnosticCounters(targetB).requests))
 	})
 
 	t.Run("does not increment when scrape request missing from context", func(t *testing.T) {
@@ -346,14 +346,14 @@ func TestScrapeRequestsTotal(t *testing.T) {
 		// request was never injected into the context (i.e. the mustScrapeRequest middleware
 		// was bypassed). These are not genuine scrape attempts and should not be counted.
 		target := "no-context.test:1"
-		before := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target))
+		before := testutil.ToFloat64(fetchDiagnosticCounters(target).requests)
 
 		r := httptest.NewRequest(http.MethodGet, "/redfish", nil)
 		w := httptest.NewRecorder()
 		metricsHandler()(w, r)
 
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
-		assert.Equal(t, before, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target)))
+		assert.Equal(t, before, testutil.ToFloat64(fetchDiagnosticCounters(target).requests))
 	})
 }
 
@@ -372,35 +372,35 @@ func TestScrapeSuccessesTotal(t *testing.T) {
 		t.Cleanup(rfServer.Close)
 
 		target := rfServer.Listener.Addr().String()
-		before := testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target))
+		before := testutil.ToFloat64(fetchDiagnosticCounters(target).successes)
 
 		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(target, nil))
 
-		assert.Equal(t, before+1, testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target)))
+		assert.Equal(t, before+1, testutil.ToFloat64(fetchDiagnosticCounters(target).successes))
 	})
 
 	t.Run("does not increment when connection fails", func(t *testing.T) {
 		// An unreachable target means NewRedfishCollector fails and no collectors run,
 		// so CollectorOutcome() returns failed > 0 and the success counter must not increment.
 		target := "unreachable-success.test:1"
-		before := testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target))
+		before := testutil.ToFloat64(fetchDiagnosticCounters(target).successes)
 
 		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(target, nil))
 
-		assert.Equal(t, before, testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target)))
+		assert.Equal(t, before, testutil.ToFloat64(fetchDiagnosticCounters(target).successes))
 	})
 
 	t.Run("requests and successes counters are independent", func(t *testing.T) {
 		// Verifies that a failed scrape increments requests but not successes,
 		// so the difference between the two counters reflects the failure count.
 		target := "independent-counters.test:1"
-		beforeReqs := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target))
-		beforeSucc := testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target))
+		beforeReqs := testutil.ToFloat64(fetchDiagnosticCounters(target).requests)
+		beforeSucc := testutil.ToFloat64(fetchDiagnosticCounters(target).successes)
 
 		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(target, nil))
 
-		assert.Equal(t, beforeReqs+1, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target)))
-		assert.Equal(t, beforeSucc, testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target)))
+		assert.Equal(t, beforeReqs+1, testutil.ToFloat64(fetchDiagnosticCounters(target).requests))
+		assert.Equal(t, beforeSucc, testutil.ToFloat64(fetchDiagnosticCounters(target).successes))
 	})
 }
 


### PR DESCRIPTION
scrape_requests_total and scrape_successes_total were registered on the default registerer and served at /metrics, so they only carried pod-level labels plus an exporter-set target= label. They now live on the per-request prometheus.Registry built inside metricsHandler and emit at /redfish?target=X alongside the redfish collectors, picking up the NetBox SD labels (hostname, oob_ip, rack, ...) attached by Prometheus during scraping.

The target= label on the metric itself is dropped, since Prometheus's instance label already identifies the target. Counters are now plain prometheus.Counter held one per target in a sync.Map; update tests to read them via the new scrapeCountersFor() helper.