### PR TITLE
propagate BMC HTTP status code instead of returning 500 for all connection failures

### DIFF
--- a/cmd/redfish-exporter/main.go
+++ b/cmd/redfish-exporter/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/exporter-toolkit/web"
 	"github.com/stmcginnis/gofish"
+	"github.com/stmcginnis/gofish/schemas"
 )
 
 type (
@@ -212,7 +213,12 @@ func metricsHandler() http.HandlerFunc {
 
 		if err != nil {
 			scrapeLogger.With("error", err).Error("unable to create redfish aggregate collector, bailing")
-			http.Error(w, "unable to construct aggregate collector", 500)
+			statusCode := http.StatusInternalServerError
+			var rfErr *schemas.Error
+			if errors.As(err, &rfErr) && rfErr.HTTPReturnedStatusCode != 0 {
+				statusCode = rfErr.HTTPReturnedStatusCode
+			}
+			http.Error(w, fmt.Sprintf("unable to construct aggregate collector: %s", err), statusCode)
 			return
 		}
 


### PR DESCRIPTION
The current code throws a 500 regardless of the actual issue, which is misleading when the issue actually is with credentials.