### PR TITLE
revert #66 scrape request counter while preserving PR #67 success metrics

### DIFF
--- a/cmd/redfish-exporter/main.go
+++ b/cmd/redfish-exporter/main.go
@@ -66,11 +66,6 @@ var (
 		Name: "redfish_exporter_unknown_modules_requested_total",
 		Help: "Count of requests specifying a module name not known to this exporter",
 	})
-	// scrapeRequestsTotal counts every scrape attempt per target, regardless of outcome.
-	scrapeRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "redfish_exporter_scrape_requests_total",
-		Help: "Total number of scrape requests received per target, regardless of success or failure.",
-	}, []string{"target"})
 	// scrapeSuccessesTotal counts scrapes where all sub-collectors completed without failure.
 	scrapeSuccessesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "redfish_exporter_scrape_successes_total",
@@ -106,7 +101,6 @@ func registerMetaMetrics() {
 	custom := []prometheus.Collector{
 		collectorLastStatus,
 		collectorModuleUnknown,
-		scrapeRequestsTotal,
 		scrapeSuccessesTotal,
 	}
 
@@ -201,8 +195,6 @@ func metricsHandler() http.HandlerFunc {
 			http.Error(w, "scrape request not found in context", 500)
 			return
 		}
-
-		scrapeRequestsTotal.WithLabelValues(sr.Target).Inc()
 
 		scrapeLogger := ctxLogger.With("scrape_host", sr.Target)
 		rfClientConfig := safeConfig.RedfishClientConfig()

--- a/cmd/redfish-exporter/main_test.go
+++ b/cmd/redfish-exporter/main_test.go
@@ -278,85 +278,6 @@ func newScrapeRequest(target string, hostConfig *config.HostConfig) *http.Reques
 	return r.WithContext(ctx)
 }
 
-// TestScrapeRequestsTotal verifies that redfish_exporter_scrape_requests_total is incremented
-// correctly across different scrape outcomes. The counter is intended to always reflect the
-// number of scrape attempts per target, regardless of whether the scrape succeeded or failed,
-// so that operators can detect missing or failing endpoints even when no other metrics are emitted.
-func TestScrapeRequestsTotal(t *testing.T) {
-	// Use a minimal safeConfig so metricsHandler can call RedfishClientConfig().
-	safeConfig = config.NewSafeConfig("")
-
-	// Each sub-test uses a unique target address so its counter label starts at zero,
-	// allowing absolute value assertions without resetting shared state.
-
-	t.Run("increments on failed connection", func(t *testing.T) {
-		// Verifies the counter is incremented even when the Redfish connection fails entirely.
-		// This is the primary motivation for the metric: scrape attempts that produce no metrics
-		// at all (e.g. host unreachable, TLS error) must still be counted so gaps in other
-		// metrics can be attributed to collection failure rather than a healthy absence of data.
-		target := "unreachable-failed.test:1"
-		before := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target))
-
-		w := httptest.NewRecorder()
-		metricsHandler()(w, newScrapeRequest(target, nil))
-
-		assert.Equal(t, http.StatusInternalServerError, w.Code)
-		assert.Equal(t, before+1, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target)))
-	})
-
-	t.Run("increments on successful scrape", func(t *testing.T) {
-		// Verifies the counter is also incremented on the happy path, where the Redfish
-		// endpoint is reachable and the handler proceeds to collect metrics.
-		// newRedfishClient always dials https://, so a TLS server is required here.
-		// Insecure: true is hardcoded in newRedfishClient, so the self-signed test cert is accepted.
-		rfServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{"@odata.id": r.URL.Path})
-		}))
-		t.Cleanup(rfServer.Close)
-
-		target := rfServer.Listener.Addr().String()
-		before := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target))
-
-		w := httptest.NewRecorder()
-		metricsHandler()(w, newScrapeRequest(target, nil))
-		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Equal(t, before+1, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target)))
-	})
-
-	t.Run("counts are per target", func(t *testing.T) {
-		// Verifies that the counter uses the target address as a label, so each host's
-		// scrape count is tracked independently and requests to one target do not affect another.
-		targetA := "per-target-a.test:1"
-		targetB := "per-target-b.test:1"
-		beforeA := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(targetA))
-		beforeB := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(targetB))
-
-		// Scrape targetA twice and targetB once, then verify the expected increments.
-		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(targetA, nil))
-		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(targetA, nil))
-		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(targetB, nil))
-
-		assert.Equal(t, beforeA+2, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(targetA)))
-		assert.Equal(t, beforeB+1, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(targetB)))
-	})
-
-	t.Run("does not increment when scrape request missing from context", func(t *testing.T) {
-		// Verifies the counter is NOT incremented for malformed requests where the scrape
-		// request was never injected into the context (i.e. the mustScrapeRequest middleware
-		// was bypassed). These are not genuine scrape attempts and should not be counted.
-		target := "no-context.test:1"
-		before := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target))
-
-		r := httptest.NewRequest(http.MethodGet, "/redfish", nil)
-		w := httptest.NewRecorder()
-		metricsHandler()(w, r)
-
-		assert.Equal(t, http.StatusInternalServerError, w.Code)
-		assert.Equal(t, before, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target)))
-	})
-}
-
 // TestScrapeSuccessesTotal verifies that redfish_exporter_scrape_successes_total is incremented
 // only when all sub-collectors in the scrape session completed without failure.
 func TestScrapeSuccessesTotal(t *testing.T) {
@@ -388,19 +309,6 @@ func TestScrapeSuccessesTotal(t *testing.T) {
 		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(target, nil))
 
 		assert.Equal(t, before, testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target)))
-	})
-
-	t.Run("requests and successes counters are independent", func(t *testing.T) {
-		// Verifies that a failed scrape increments requests but not successes,
-		// so the difference between the two counters reflects the failure count.
-		target := "independent-counters.test:1"
-		beforeReqs := testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target))
-		beforeSucc := testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target))
-
-		metricsHandler()(httptest.NewRecorder(), newScrapeRequest(target, nil))
-
-		assert.Equal(t, beforeReqs+1, testutil.ToFloat64(scrapeRequestsTotal.WithLabelValues(target)))
-		assert.Equal(t, beforeSucc, testutil.ToFloat64(scrapeSuccessesTotal.WithLabelValues(target)))
 	})
 }
 


### PR DESCRIPTION
A normal revert of #66 would not work because #67 was built on top of it and reuses part of its test scaffolding. This keeps #67's  success metric intact while removing the request counter behavior that was decided against. The resulting diff is intentionally minimal to avoid reverting unrelated collector work from PR #67.