### PR TITLE
chassis_collector: keep the chassis that did answer

### DIFF
--- a/internal/collector/chassis_collector.go
+++ b/internal/collector/chassis_collector.go
@@ -138,159 +138,164 @@ func (c *ChassisCollector) collect(ctx context.Context, ch chan<- prometheus.Met
 		return
 	}
 	// get a list of chassis from service
-	if chassises, err := service.Chassis(); err != nil {
+	chassises, err := service.Chassis()
+	if err != nil {
+		// A collection error means some member failed, not that none of them arrived:
+		// gofish still returns the chassis it did fetch. Discarding those made one flaky
+		// chassis out of forty silently zero the whole chassis scrape, which reads as a
+		// host with no chassis rather than as a host with a problem.
 		logger.Error("error getting chassis from service", slog.String("operation", "service.Chassis()"), slog.Any("error", err))
-	} else {
-		// process the chassises
-		for _, chassis := range chassises {
-			if ctx.Err() != nil {
-				c.logger.With("error", ctx.Err()).Warn("skipping further collection")
-				continue
-			}
-			chassisLogger := logger.With(slog.String("Chassis", chassis.ID))
-			chassisLogger.Info("collector scrape started")
-			chassisID := chassis.ID
-			chassisStatus := chassis.Status
-			chassisStatusState := chassisStatus.State
-			chassisStatusHealth := chassisStatus.Health
-			chassisStatusHealthRollup := chassisStatus.HealthRollup
-			ChassisLabelValues := []string{"chassis", chassisID}
-			if chassisStatusHealthValue, ok := parseCommonStatusHealth(chassisStatusHealth); ok {
-				ch <- prometheus.MustNewConstMetric(c.metrics["chassis_health"].desc, prometheus.GaugeValue, chassisStatusHealthValue, ChassisLabelValues...)
-			}
-			if chassisStatusHealthRollupValue, ok := parseCommonStatusHealth(chassisStatusHealthRollup); ok {
-				ch <- prometheus.MustNewConstMetric(c.metrics["chassis_health_rollup"].desc, prometheus.GaugeValue, chassisStatusHealthRollupValue, ChassisLabelValues...)
-			}
-			if chassisStatusStateValue, ok := parseCommonStatusState(chassisStatusState); ok {
-				ch <- prometheus.MustNewConstMetric(c.metrics["chassis_state"].desc, prometheus.GaugeValue, chassisStatusStateValue, ChassisLabelValues...)
-			}
+	}
 
-			chassisManufacturer := chassis.Manufacturer
-			chassisModel := chassis.Model
-			chassisPartNumber := chassis.PartNumber
-			chassisSKU := chassis.SKU
-			ChassisModelLabelValues := []string{"chassis", chassisID, chassisManufacturer, chassisModel, chassisPartNumber, chassisSKU}
-			ch <- prometheus.MustNewConstMetric(c.metrics["chassis_model_info"].desc, prometheus.GaugeValue, 1, ChassisModelLabelValues...)
-
-			chassisThermal, err := chassis.Thermal()
-			if err != nil {
-				chassisLogger.Error("error getting thermal data from chassis", slog.String("operation", "chassis.Thermal()"), slog.Any("error", err))
-			} else if chassisThermal == nil {
-				chassisLogger.Info("no thermal data found", slog.String("operation", "chassis.Thermal()"))
-			} else {
-				// process temperature and fans
-				chassisTemperatures := chassisThermal.Temperatures
-				chassisFans := chassisThermal.Fans
-				eg := newRecoverGroup(ctx)
-				for _, chassisTemperature := range chassisTemperatures {
-					eg.Go(func() error {
-						parseChassisTemperature(ch, chassisID, chassisTemperature)
-						return nil
-					})
-				}
-				for _, chassisFan := range chassisFans {
-					eg.Go(func() error {
-						parseChassisFan(ch, chassisID, chassisFan)
-						return nil
-					})
-				}
-				if err := eg.Wait(); err != nil {
-					chassisLogger.Error("goroutine error", slog.Any("error", err))
-				}
-			}
-			chassisThermalSubsystem, err := chassis.ThermalSubsystem()
-			if err != nil {
-				chassisLogger.Error("error getting thermal subsystem from chassis", slog.String("operation", "chassis.ThermalSubsystem()"), slog.Any("error", err))
-			} else if chassisThermalSubsystem == nil {
-				chassisLogger.Info("no thermal subsystem found", slog.String("operation", "chassis.ThermalSubsystem()"))
-			} else {
-				// NOTE: Handles some odd (maybe even buggy) OEM implementations of LeakDeteactor
-				leakDetectors := c.getLeakDetectors(chassisThermalSubsystem, chassisLogger)
-
-				if len(leakDetectors) > 0 {
-					egLD := newRecoverGroup(ctx)
-					for _, ld := range leakDetectors {
-						egLD.Go(func() error {
-							parseLeakDetector(ch, chassisID, ld)
-							return nil
-						})
-					}
-					if err := egLD.Wait(); err != nil {
-						chassisLogger.Error("goroutine error", slog.Any("error", err))
-					}
-				} else {
-					chassisLogger.Info("no leak detectors found")
-				}
-			}
-
-			chassisPowerInfo, err := chassis.Power()
-			if err != nil {
-				chassisLogger.Error("error getting power data from chassis", slog.String("operation", "chassis.Power()"), slog.Any("error", err))
-			} else if chassisPowerInfo == nil {
-				chassisLogger.Info("no power data found", slog.String("operation", "chassis.Power()"))
-			} else {
-				egPower := newRecoverGroup(ctx)
-
-				// power voltages
-				for _, chassisPowerInfoVoltage := range chassisPowerInfo.Voltages {
-					egPower.Go(func() error {
-						parseChassisPowerInfoVoltage(ch, chassisID, chassisPowerInfoVoltage)
-						return nil
-					})
-				}
-
-				// power control
-				for _, chassisPowerInfoPowerControl := range chassisPowerInfo.PowerControl {
-					egPower.Go(func() error {
-						parseChassisPowerInfoPowerControl(ch, chassisID, chassisPowerInfoPowerControl)
-						return nil
-					})
-				}
-
-				// powerSupply
-				for _, chassisPowerInfoPowerSupply := range chassisPowerInfo.PowerSupplies {
-					egPower.Go(func() error {
-						parseChassisPowerInfoPowerSupply(ch, chassisID, chassisPowerInfoPowerSupply)
-						return nil
-					})
-				}
-				if err := egPower.Wait(); err != nil {
-					chassisLogger.Error("goroutine error", slog.Any("error", err))
-				}
-			}
-
-			// process NetworkAdapter
-			networkAdapters, err := chassis.NetworkAdapters()
-			if err != nil {
-				chassisLogger.Error("error getting network adapters data from chassis", slog.String("operation", "chassis.NetworkAdapters()"), slog.Any("error", err))
-			} else if networkAdapters == nil {
-				chassisLogger.Info("no network adapters data found", slog.String("operation", "chassis.NetworkAdapters()"))
-			} else {
-				egNA := newRecoverGroup(ctx)
-				for _, networkAdapter := range networkAdapters {
-					egNA.Go(func() error {
-						return parseNetworkAdapter(ctx, ch, chassisID, networkAdapter)
-					})
-				}
-				if err := egNA.Wait(); err != nil {
-					chassisLogger.Error("error getting network ports from network adapter", slog.String("operation", "chassis.NetworkAdapters()"), slog.Any("error", err))
-				}
-			}
-
-			physicalSecurity := chassis.PhysicalSecurity
-			if physicalSecurity != (schemas.PhysicalSecurity{}) {
-				physicalSecurityIntrusionSensor := physicalSecurity.IntrusionSensor
-				physicalSecurityIntrusionSensorNumber := fmt.Sprint(physicalSecurity.IntrusionSensorNumber) //nolint:staticcheck
-				physicalSecurityIntrusionSensorReArmMethod := string(physicalSecurity.IntrusionSensorReArm)
-
-				if phySecIntrusionSensor, ok := parsePhySecIntrusionSensor(physicalSecurityIntrusionSensor); ok {
-					ChassisPhysicalSecurityLabelValues := []string{"physical_security", chassisID, physicalSecurityIntrusionSensorNumber, physicalSecurityIntrusionSensorReArmMethod}
-					ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_physical_security_sensor_state"].desc, prometheus.GaugeValue, phySecIntrusionSensor, ChassisPhysicalSecurityLabelValues...)
-				}
-			}
-
-			chassisLogger.Info("collector scrape completed")
+	// process the chassises
+	for _, chassis := range chassises {
+		if ctx.Err() != nil {
+			c.logger.With("error", ctx.Err()).Warn("skipping further collection")
+			continue
 		}
+		chassisLogger := logger.With(slog.String("Chassis", chassis.ID))
+		chassisLogger.Info("collector scrape started")
+		chassisID := chassis.ID
+		chassisStatus := chassis.Status
+		chassisStatusState := chassisStatus.State
+		chassisStatusHealth := chassisStatus.Health
+		chassisStatusHealthRollup := chassisStatus.HealthRollup
+		ChassisLabelValues := []string{"chassis", chassisID}
+		if chassisStatusHealthValue, ok := parseCommonStatusHealth(chassisStatusHealth); ok {
+			ch <- prometheus.MustNewConstMetric(c.metrics["chassis_health"].desc, prometheus.GaugeValue, chassisStatusHealthValue, ChassisLabelValues...)
+		}
+		if chassisStatusHealthRollupValue, ok := parseCommonStatusHealth(chassisStatusHealthRollup); ok {
+			ch <- prometheus.MustNewConstMetric(c.metrics["chassis_health_rollup"].desc, prometheus.GaugeValue, chassisStatusHealthRollupValue, ChassisLabelValues...)
+		}
+		if chassisStatusStateValue, ok := parseCommonStatusState(chassisStatusState); ok {
+			ch <- prometheus.MustNewConstMetric(c.metrics["chassis_state"].desc, prometheus.GaugeValue, chassisStatusStateValue, ChassisLabelValues...)
+		}
+
+		chassisManufacturer := chassis.Manufacturer
+		chassisModel := chassis.Model
+		chassisPartNumber := chassis.PartNumber
+		chassisSKU := chassis.SKU
+		ChassisModelLabelValues := []string{"chassis", chassisID, chassisManufacturer, chassisModel, chassisPartNumber, chassisSKU}
+		ch <- prometheus.MustNewConstMetric(c.metrics["chassis_model_info"].desc, prometheus.GaugeValue, 1, ChassisModelLabelValues...)
+
+		chassisThermal, err := chassis.Thermal()
+		if err != nil {
+			chassisLogger.Error("error getting thermal data from chassis", slog.String("operation", "chassis.Thermal()"), slog.Any("error", err))
+		} else if chassisThermal == nil {
+			chassisLogger.Info("no thermal data found", slog.String("operation", "chassis.Thermal()"))
+		} else {
+			// process temperature and fans
+			chassisTemperatures := chassisThermal.Temperatures
+			chassisFans := chassisThermal.Fans
+			eg := newRecoverGroup(ctx)
+			for _, chassisTemperature := range chassisTemperatures {
+				eg.Go(func() error {
+					parseChassisTemperature(ch, chassisID, chassisTemperature)
+					return nil
+				})
+			}
+			for _, chassisFan := range chassisFans {
+				eg.Go(func() error {
+					parseChassisFan(ch, chassisID, chassisFan)
+					return nil
+				})
+			}
+			if err := eg.Wait(); err != nil {
+				chassisLogger.Error("goroutine error", slog.Any("error", err))
+			}
+		}
+		chassisThermalSubsystem, err := chassis.ThermalSubsystem()
+		if err != nil {
+			chassisLogger.Error("error getting thermal subsystem from chassis", slog.String("operation", "chassis.ThermalSubsystem()"), slog.Any("error", err))
+		} else if chassisThermalSubsystem == nil {
+			chassisLogger.Info("no thermal subsystem found", slog.String("operation", "chassis.ThermalSubsystem()"))
+		} else {
+			// NOTE: Handles some odd (maybe even buggy) OEM implementations of LeakDeteactor
+			leakDetectors := c.getLeakDetectors(chassisThermalSubsystem, chassisLogger)
+
+			if len(leakDetectors) > 0 {
+				egLD := newRecoverGroup(ctx)
+				for _, ld := range leakDetectors {
+					egLD.Go(func() error {
+						parseLeakDetector(ch, chassisID, ld)
+						return nil
+					})
+				}
+				if err := egLD.Wait(); err != nil {
+					chassisLogger.Error("goroutine error", slog.Any("error", err))
+				}
+			} else {
+				chassisLogger.Info("no leak detectors found")
+			}
+		}
+
+		chassisPowerInfo, err := chassis.Power()
+		if err != nil {
+			chassisLogger.Error("error getting power data from chassis", slog.String("operation", "chassis.Power()"), slog.Any("error", err))
+		} else if chassisPowerInfo == nil {
+			chassisLogger.Info("no power data found", slog.String("operation", "chassis.Power()"))
+		} else {
+			egPower := newRecoverGroup(ctx)
+
+			// power voltages
+			for _, chassisPowerInfoVoltage := range chassisPowerInfo.Voltages {
+				egPower.Go(func() error {
+					parseChassisPowerInfoVoltage(ch, chassisID, chassisPowerInfoVoltage)
+					return nil
+				})
+			}
+
+			// power control
+			for _, chassisPowerInfoPowerControl := range chassisPowerInfo.PowerControl {
+				egPower.Go(func() error {
+					parseChassisPowerInfoPowerControl(ch, chassisID, chassisPowerInfoPowerControl)
+					return nil
+				})
+			}
+
+			// powerSupply
+			for _, chassisPowerInfoPowerSupply := range chassisPowerInfo.PowerSupplies {
+				egPower.Go(func() error {
+					parseChassisPowerInfoPowerSupply(ch, chassisID, chassisPowerInfoPowerSupply)
+					return nil
+				})
+			}
+			if err := egPower.Wait(); err != nil {
+				chassisLogger.Error("goroutine error", slog.Any("error", err))
+			}
+		}
+
+		// process NetworkAdapter
+		networkAdapters, err := chassis.NetworkAdapters()
+		if err != nil {
+			chassisLogger.Error("error getting network adapters data from chassis", slog.String("operation", "chassis.NetworkAdapters()"), slog.Any("error", err))
+		} else if networkAdapters == nil {
+			chassisLogger.Info("no network adapters data found", slog.String("operation", "chassis.NetworkAdapters()"))
+		} else {
+			egNA := newRecoverGroup(ctx)
+			for _, networkAdapter := range networkAdapters {
+				egNA.Go(func() error {
+					return parseNetworkAdapter(ctx, ch, chassisID, networkAdapter)
+				})
+			}
+			if err := egNA.Wait(); err != nil {
+				chassisLogger.Error("error getting network ports from network adapter", slog.String("operation", "chassis.NetworkAdapters()"), slog.Any("error", err))
+			}
+		}
+
+		physicalSecurity := chassis.PhysicalSecurity
+		if physicalSecurity != (schemas.PhysicalSecurity{}) {
+			physicalSecurityIntrusionSensor := physicalSecurity.IntrusionSensor
+			physicalSecurityIntrusionSensorNumber := fmt.Sprint(physicalSecurity.IntrusionSensorNumber) //nolint:staticcheck
+			physicalSecurityIntrusionSensorReArmMethod := string(physicalSecurity.IntrusionSensorReArm)
+
+			if phySecIntrusionSensor, ok := parsePhySecIntrusionSensor(physicalSecurityIntrusionSensor); ok {
+				ChassisPhysicalSecurityLabelValues := []string{"physical_security", chassisID, physicalSecurityIntrusionSensorNumber, physicalSecurityIntrusionSensorReArmMethod}
+				ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_physical_security_sensor_state"].desc, prometheus.GaugeValue, phySecIntrusionSensor, ChassisPhysicalSecurityLabelValues...)
+			}
+		}
+
+		chassisLogger.Info("collector scrape completed")
 	}
 
 	c.collectorScrapeStatus.WithLabelValues("chassis").Set(float64(1))

--- a/internal/collector/chassis_collector_test.go
+++ b/internal/collector/chassis_collector_test.go
@@ -1,8 +1,12 @@
 package collector
 
 import (
+	"context"
 	"io"
 	"log/slog"
+	"maps"
+	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -13,6 +17,91 @@ import (
 	"github.com/stmcginnis/gofish"
 	"github.com/stretchr/testify/require"
 )
+
+// collectedMetric is a drained prometheus.Metric flattened for assertions.
+type collectedMetric struct {
+	fqName string
+	labels map[string]string
+	value  float64
+}
+
+// drainMetrics closes ch and flattens everything on it, keyed by metric name. A metric
+// name may appear more than once when a family covers several sensors or detectors.
+func drainMetrics(t *testing.T, ch chan prometheus.Metric) map[string][]collectedMetric {
+	t.Helper()
+	close(ch)
+
+	out := map[string][]collectedMetric{}
+	for metric := range ch {
+		d := &dto.Metric{}
+		require.NoError(t, metric.Write(d))
+
+		match := fqNameRe.FindStringSubmatch(metric.Desc().String())
+		require.Len(t, match, 2, "could not extract fqName from %s", metric.Desc().String())
+
+		labels := map[string]string{}
+		for _, label := range d.Label {
+			labels[label.GetName()] = label.GetValue()
+		}
+
+		require.NotNil(t, d.Gauge, "expected gauge metric for %s", match[1])
+		out[match[1]] = append(out[match[1]], collectedMetric{
+			fqName: match[1],
+			labels: labels,
+			value:  d.Gauge.GetValue(),
+		})
+	}
+	return out
+}
+
+// requireMetric asserts exactly one sample exists for name and returns it.
+//
+//nolint:unused // part of the drainMetrics harness; its first callers land with the Sensors and telemetry tests.
+func requireMetric(t *testing.T, metrics map[string][]collectedMetric, name string) collectedMetric {
+	t.Helper()
+	samples, ok := metrics[name]
+	require.True(t, ok, "expected metric %s to be emitted, got %v", name, slices.Sorted(maps.Keys(metrics)))
+	require.Len(t, samples, 1, "expected exactly one sample for %s", name)
+	return samples[0]
+}
+
+// TestCollectSurvivesOneUnreachableChassis pins the behaviour that a single failing member
+// of the chassis collection must not discard the members that did answer.
+func TestCollectSurvivesOneUnreachableChassis(t *testing.T) {
+	server := newTestRedfishServer(t)
+	server.addRoute("/redfish/v1/Chassis", map[string]any{
+		"@odata.id":   "/redfish/v1/Chassis",
+		"@odata.type": "#ChassisCollection.ChassisCollection",
+		"Members": []map[string]string{
+			{"@odata.id": "/redfish/v1/Chassis/Chassis_0"},
+			{"@odata.id": "/redfish/v1/Chassis/Chassis_1"},
+		},
+	})
+	server.addRoute("/redfish/v1/Chassis/Chassis_0", map[string]any{
+		"@odata.id":   "/redfish/v1/Chassis/Chassis_0",
+		"@odata.type": "#Chassis.v1_22_0.Chassis",
+		"Id":          "Chassis_0",
+		"Status":      map[string]any{"Health": "OK", "State": "Enabled"},
+	})
+	server.addErrorRoute("/redfish/v1/Chassis/Chassis_1", http.StatusInternalServerError)
+
+	client := connectToTestServer(t, server.Server)
+	t.Cleanup(func() {
+		client.Logout()
+		server.Close()
+	})
+
+	collector, err := NewChassisCollector(t.Name(), client, NewTestLogger(t, slog.LevelDebug), config.DefaultChassisCollector)
+	require.NoError(t, err)
+
+	ch := make(chan prometheus.Metric, 128)
+	collector.CollectWithContext(context.Background(), ch)
+	metrics := drainMetrics(t, ch)
+
+	health := metrics["redfish_chassis_health"]
+	require.Len(t, health, 1, "the healthy chassis must still be collected")
+	require.Equal(t, "Chassis_0", health[0].labels["chassis_id"])
+}
 
 func TestGetLeakDetectors(t *testing.T) {
 	tT := map[string]struct {

--- a/internal/collector/testutil_test.go
+++ b/internal/collector/testutil_test.go
@@ -83,6 +83,25 @@ func (m *testRedfishServer) addRouteFromFixture(path string, fixtureFile string)
 	m.addRoute(path, data)
 }
 
+// addErrorRoute registers a route that responds with the given HTTP status and a Redfish
+// error body. Used to reproduce BMCs that advertise a resource which then does not exist.
+func (m *testRedfishServer) addErrorRoute(path string, status int) {
+	m.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		m.requests = append(m.requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		body := map[string]any{
+			"error": map[string]any{
+				"code":    "Base.v1_10_3.GeneralError",
+				"message": "A general error has occurred. See ExtendedInfo for more information.",
+			},
+		}
+		if err := json.NewEncoder(w).Encode(body); err != nil {
+			m.t.Errorf("Failed to encode error response: %v", err)
+		}
+	})
+}
+
 // loadFixture loads a JSON fixture and returns it
 func (m *testRedfishServer) loadFixture(fixtureFile string) map[string]interface{} {
 	return loadTestData(m.t, fixtureFile)


### PR DESCRIPTION
> **Reviewer note:** read this with `git show -w` / "Hide whitespace changes". The behavioural
> change is nine lines; everything else is re-indentation from de-nesting an `else`.

## What

gofish reports a collection error when *any* single member of a collection fails, and still returns the members that succeeded. `collect()` branched away from the result on error:
```go
if chassises, err := service.Chassis(); err != nil {
    logger.Error(...)
} else {
    // ~200 lines, skipped entirely
}
```

So one chassis returning a 500 discarded the other forty-one. A host with one flaky component
presented as a host with no chassis at all;  the series vanish rather than degrade, and a missing series fires nothing.

De-nest it, log the failure, and collect what arrived.

## Also in this PR

The shared test harness the rest of the decomposition of [PR#76](https://github.com/LambdaLabs/redfish_exporter/pull/76) builds on, kept here so it lands once rather than three times:
- `collectedMetric` / `drainMetrics` / `requireMetric` — drain a `prometheus.Metric` channel   into something assertable. Reuses the existing `fqNameRe` from `powershelf_collector_test.go`.
- `testRedfishServer.addErrorRoute` — respond with an HTTP status and a Redfish error body, for reproducing BMCs that advertise a resource which then does not exist.

`requireMetric` carries a `//nolint:unused` here; its first callers arrive in a follow on PR, which removes the directive.

