### PR TITLE
chassis_collector: capture NVL72 trays through the Sensors collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Forked from https://github.com/FlxPeters/redfish_exporter, see [Why a fork](#why
 
 Configuration of the redfish_exporter is done via YAML file.
 
-See [CONFIGURATION.md](./docs/CONFIGURATION.md) for details.
+See [CONFIGURATION.md](./docs/CONFIGURATION.md) for details, and
+[PLATFORMS.md](./docs/PLATFORMS.md) for where a platform's Redfish implementation makes the
+exporter behave differently from that description.
 
 ## Building
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -83,37 +83,9 @@ The Chassis Collector primarily exposes health data from the Chassis API. Agains
 # TYPE redfish_chassis_state gauge
 ```
 
-Newer platforms — notably the GB200/GB300 NVL72 trays and the MGX NVSwitch tray — do not
-implement the deprecated `Thermal` and `Power` schemas at all, and express the same
-readings through `Sensors` instead. For those chassis the collector falls back to the
-`Sensors` collection, folding readings into the metric families above wherever the meaning
-is unambiguous, so a Sensors-only platform produces the same series names as one that
-implements `Thermal`/`Power`:
-
-| Redfish `ReadingType` | Metric |
-| --- | --- |
-| `Temperature` | `redfish_chassis_temperature_celsius` (+ `_sensor_health`, `_sensor_state`) |
-| `Rotational` | `redfish_chassis_fan_rpm` (+ min/max/percentage/threshold series) |
-| `Voltage` | `redfish_chassis_power_voltage_volts` (+ `_state`) |
-| anything else | `redfish_chassis_sensor_{watts,amperes,joules,hertz,percent,reading}` |
-
-The collection is consulted only on a chassis that advertises neither `Thermal` nor `Power`.
-Collecting it alongside them would publish that chassis's temperatures twice under the same
-series name, which fails the whole scrape at registration rather than merely thinning it.
-
-A chassis advertising no `Sensors` collection is never asked for one. This matters more
-than it sounds: the `ERoT`/`IRoT` roots are roughly a third of the chassis on an NVL72 tray
-or an HGX baseboard, and synthesising `<chassis>/Sensors` for them would cost a 404 apiece
-on every scrape.
-
-Readings are not inferred from sensor naming: fan PWM duty cycle and CPU core utilisation
-are both `ReadingType: Percent` and neither carries a distinguishing `PhysicalContext`, so
-`Percent` reaches the catch-all rather than being assumed to be a fan speed.
-
-The collection is fetched with `$expand` so the BMC inlines every member body, costing one
-request per chassis rather than one per sensor. A BMC that does not honour `$expand` is
-**not** fanned out to one request per sensor — that would multiply load against the BMCs
-least able to absorb it — so the bulk sensor telemetry is skipped with a warning instead.
+On a platform implementing neither `Thermal` nor `Power` the same readings are collected
+from the `Sensors` collection instead; see
+[Platform differences](./PLATFORMS.md#chassis-sensors-instead-of-thermalpower).
 
 Exposes no user configuration.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -83,6 +83,38 @@ The Chassis Collector primarily exposes health data from the Chassis API. Agains
 # TYPE redfish_chassis_state gauge
 ```
 
+Newer platforms — notably the GB200/GB300 NVL72 trays and the MGX NVSwitch tray — do not
+implement the deprecated `Thermal` and `Power` schemas at all, and express the same
+readings through `Sensors` instead. For those chassis the collector falls back to the
+`Sensors` collection, folding readings into the metric families above wherever the meaning
+is unambiguous, so a Sensors-only platform produces the same series names as one that
+implements `Thermal`/`Power`:
+
+| Redfish `ReadingType` | Metric |
+| --- | --- |
+| `Temperature` | `redfish_chassis_temperature_celsius` (+ `_sensor_health`, `_sensor_state`) |
+| `Rotational` | `redfish_chassis_fan_rpm` (+ min/max/percentage/threshold series) |
+| `Voltage` | `redfish_chassis_power_voltage_volts` (+ `_state`) |
+| anything else | `redfish_chassis_sensor_{watts,amperes,joules,hertz,percent,reading}` |
+
+The collection is consulted only on a chassis that advertises neither `Thermal` nor `Power`.
+Collecting it alongside them would publish that chassis's temperatures twice under the same
+series name, which fails the whole scrape at registration rather than merely thinning it.
+
+A chassis advertising no `Sensors` collection is never asked for one. This matters more
+than it sounds: the `ERoT`/`IRoT` roots are roughly a third of the chassis on an NVL72 tray
+or an HGX baseboard, and synthesising `<chassis>/Sensors` for them would cost a 404 apiece
+on every scrape.
+
+Readings are not inferred from sensor naming: fan PWM duty cycle and CPU core utilisation
+are both `ReadingType: Percent` and neither carries a distinguishing `PhysicalContext`, so
+`Percent` reaches the catch-all rather than being assumed to be a fan speed.
+
+The collection is fetched with `$expand` so the BMC inlines every member body, costing one
+request per chassis rather than one per sensor. A BMC that does not honour `$expand` is
+**not** fanned out to one request per sensor — that would multiply load against the BMCs
+least able to absorb it — so the bulk sensor telemetry is skipped with a warning instead.
+
 Exposes no user configuration.
 
 ### `<gpu_collector>`

--- a/docs/PLATFORMS.md
+++ b/docs/PLATFORMS.md
@@ -1,0 +1,47 @@
+# Platform differences
+
+Where a platform's Redfish implementation makes this exporter behave differently from the
+description in [CONFIGURATION.md](./CONFIGURATION.md), the reason is recorded here.
+
+## Chassis: `Sensors` instead of `Thermal`/`Power`
+
+Newer platforms — notably the GB200/GB300 NVL72 trays and the MGX NVSwitch tray — do not
+implement the deprecated `Thermal` and `Power` schemas at all, and express the same
+readings through `Sensors` instead. For those chassis the chassis collector falls back to
+the `Sensors` collection, folding readings into the existing metric families wherever the
+meaning is unambiguous, so a Sensors-only platform produces the same series names as one
+that implements `Thermal`/`Power`:
+
+| Redfish `ReadingType` | Metric |
+| --- | --- |
+| `Temperature` | `redfish_chassis_temperature_celsius` (+ `_sensor_health`, `_sensor_state`) |
+| `Rotational` | `redfish_chassis_fan_rpm` (+ min/max/percentage/threshold series, `redfish_chassis_fan_health`, `_fan_state`) |
+| `Voltage` | `redfish_chassis_power_voltage_volts` (+ `_state`) |
+| anything else | `redfish_chassis_sensor_{watts,amperes,joules,hertz,percent,reading}` (+ `_health`, `_state`) |
+
+The collection is consulted only on a chassis that advertises neither `Thermal` nor `Power`.
+Collecting it alongside them would publish that chassis's temperatures twice under the same
+series name, which fails the whole scrape at registration rather than merely thinning it.
+
+A chassis advertising no `Sensors` collection is never asked for one. This matters more
+than it sounds: the `ERoT`/`IRoT` roots are roughly a third of the chassis on an NVL72 tray
+or an HGX baseboard, and synthesising `<chassis>/Sensors` for them would cost a 404 apiece
+on every scrape.
+
+Readings are not inferred from sensor naming: fan PWM duty cycle and CPU core utilisation
+are both `ReadingType: Percent` and neither carries a distinguishing `PhysicalContext`, so
+`Percent` reaches the catch-all rather than being assumed to be a fan speed.
+
+Leak detectors are left out of this pass. A detector is dual-surfaced: a `LeakDetector`
+resource carries its state, and a `Sensor` of the same Id carries an analog voltage. That
+sensor is `ReadingType: Voltage` like any other, so folding it in would report a leak signal
+as a rail measurement — the detector Ids enumerated from `ThermalSubsystem` are used to skip
+it, leaving it to the leak detection path, which is the only thing able to interpret it
+against its thresholds.
+
+The collection is fetched with `$expand` so the BMC inlines every member body, costing one
+request per chassis rather than one per sensor. A BMC that does not honour `$expand` is
+**not** fanned out to one request per sensor — that would multiply load against the BMCs
+least able to absorb it — so the unexpanded members are skipped with a warning instead. A
+paginated collection is reported the same way rather than followed page by page, for the
+same reason. Nothing is dropped silently.

--- a/internal/collector/chassis_collector.go
+++ b/internal/collector/chassis_collector.go
@@ -304,19 +304,17 @@ func (c *ChassisCollector) collect(ctx context.Context, ch chan<- prometheus.Met
 		// name, failing the scrape at registration.
 		if !links.legacyThermalOrPower() {
 			sensorsPath := links.sensorsPath(chassis)
-			sensors, err := c.getChassisSensors(ctx, sensorsPath, chassisLogger)
-			if err != nil {
-				chassisLogger.Error("error getting sensors from chassis", slog.String("operation", "chassis.Sensors()"), slog.Any("error", err))
-			} else if len(sensors) == 0 {
-				chassisLogger.Debug("no sensors found", slog.String("operation", "chassis.Sensors()"))
+			// getChassisSensors warns about anything it could not collect, so an empty
+			// answer here only means this chassis published none.
+			sensors := c.getChassisSensors(ctx, sensorsPath, chassisLogger)
+			if len(sensors) == 0 {
+				chassisLogger.Info("no sensors found", slog.String("operation", "GET "+sensorsPath))
 			} else {
 				// Parsing a sensor is a handful of channel sends, so this stays a plain
 				// loop; a goroutine per sensor would be several hundred per tray to save
-				// nothing.
+				// nothing. A panic in one is still contained, by the recover group the
+				// whole chassis collection runs under.
 				for _, sensor := range sensors {
-					if sensor == nil {
-						continue
-					}
 					// A leak detector's companion sensor is a leak signal, not a chassis
 					// voltage, and publishing it as one would misreport it. It is left to
 					// the leak detection path, which is the only thing able to interpret
@@ -378,14 +376,17 @@ func (c *ChassisCollector) Describe(ch chan<- *prometheus.Desc) {
 // full Sensor bodies rather than links, so one request replaces one-per-sensor.
 type sensorCollection struct {
 	Members []*schemas.Sensor `json:"Members"`
+	// NextLink is set when the BMC paginated the collection, which this collector reports
+	// rather than follows.
+	NextLink string `json:"Members@odata.nextLink"`
 }
 
 // chassisLinks are the subordinate resource URIs advertised by a chassis payload.
 //
-// gofish parses the same links but keeps them unexported, so they are re-read from the raw
-// payload here. Reading the advertised links rather than inferring from a fetch means the
-// answers do not change when a subsystem is disabled by configuration, and that a resource
-// the chassis never advertises is never requested.
+// gofish parses the same links but keeps them unexported, and its Chassis.Sensors() fans out
+// one request per member, so the URIs are re-read from the raw payload here. Reading what the
+// chassis advertises rather than inferring it from a fetch means a resource the chassis never
+// advertises is never requested.
 type chassisLinks struct {
 	thermal string
 	power   string
@@ -396,22 +397,28 @@ type chassisLinks struct {
 }
 
 // chassisAdvertisedLinks extracts the links this collector decides on from a chassis.
+//
+// The references are read through schemas.Link, the same type gofish parses them with, so
+// the two cannot disagree about whether a chassis advertises Thermal. A reference object
+// may spell its URI "href" rather than "@odata.id", and reading only the latter would leave
+// gofish collecting a chassis's Thermal while this concluded it had none — publishing that
+// chassis's temperatures from both paths at once, which fails the scrape at registration.
 func chassisAdvertisedLinks(chassis *schemas.Chassis) chassisLinks {
 	if len(chassis.RawData) == 0 {
 		return chassisLinks{opaque: true}
 	}
 	var raw struct {
-		Thermal odataLink `json:"Thermal"`
-		Power   odataLink `json:"Power"`
-		Sensors odataLink `json:"Sensors"`
+		Thermal schemas.Link `json:"Thermal"`
+		Power   schemas.Link `json:"Power"`
+		Sensors schemas.Link `json:"Sensors"`
 	}
 	if err := json.Unmarshal(chassis.RawData, &raw); err != nil {
 		return chassisLinks{opaque: true}
 	}
 	return chassisLinks{
-		thermal: raw.Thermal.ODataID,
-		power:   raw.Power.ODataID,
-		sensors: raw.Sensors.ODataID,
+		thermal: raw.Thermal.String(),
+		power:   raw.Power.String(),
+		sensors: raw.Sensors.String(),
 	}
 }
 
@@ -446,41 +453,74 @@ func (l chassisLinks) sensorsPath(chassis *schemas.Chassis) string {
 //
 // If the BMC does not honour $expand there is deliberately no fan-out to one request per
 // sensor: that would multiply request count against the BMCs least able to absorb it. The
-// bulk sensor telemetry is skipped with a warning instead.
-func (c *ChassisCollector) getChassisSensors(ctx context.Context, sensorsPath string, logger *slog.Logger) ([]*schemas.Sensor, error) {
+// bulk sensor telemetry is skipped instead.
+//
+// Nothing here fails the chassis: every way this can go wrong is the BMC answering for its
+// own Sensors collection badly, and the answer is always the same — collect what arrived and
+// warn about what did not, naming the collection. The caller has no decision left to make,
+// which is why no error is returned.
+func (c *ChassisCollector) getChassisSensors(ctx context.Context, sensorsPath string, logger *slog.Logger) []*schemas.Sensor {
 	if sensorsPath == "" {
-		return nil, nil
+		return nil
 	}
 	rfClient := c.redfishClient.WithContext(ctx)
 
+	// The path came from the chassis's own advertisement, so a failure here is the BMC
+	// contradicting itself.
 	response, err := rfClient.Get(sensorsPath + `?$expand=.($levels=1)`)
 	if err != nil {
-		logger.Debug("expanded Sensors request failed", slog.Any("error", err))
-		return nil, nil
+		logger.Warn("expanded Sensors request failed; skipping sensor collection",
+			slog.String("sensors", sensorsPath),
+			slog.Any("error", err),
+		)
+		return nil
 	}
 	defer response.Body.Close() //nolint:errcheck
 
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
-		return nil, err
+		logger.Warn("could not read the Sensors collection; skipping sensor collection",
+			slog.String("sensors", sensorsPath),
+			slog.Any("error", err),
+		)
+		return nil
 	}
 
 	var agg sensorCollection
 	if err := json.Unmarshal(body, &agg); err != nil {
-		return nil, err
-	}
-	// A BMC that ignores $expand answers with link-only members, which unmarshal into
-	// Sensors carrying no Id.
-	if len(agg.Members) > 0 && agg.Members[0] != nil && agg.Members[0].ID != "" {
-		return agg.Members, nil
-	}
-	if len(agg.Members) > 0 {
-		logger.Warn("BMC did not honour $expand on Sensors; skipping bulk sensor collection",
+		logger.Warn("could not parse the Sensors collection; skipping sensor collection",
 			slog.String("sensors", sensorsPath),
-			slog.Int("skipped", len(agg.Members)),
+			slog.Any("error", err),
+		)
+		return nil
+	}
+	if agg.NextLink != "" {
+		// Following the pages would be a request apiece, which is the fan-out this collector
+		// exists to avoid, so the tail is dropped — but never silently.
+		logger.Warn("Sensors collection is paginated; collecting the first page only",
+			slog.String("sensors", sensorsPath),
+			slog.String("next", agg.NextLink),
+			slog.Int("collected", len(agg.Members)),
 		)
 	}
-	return nil, nil
+
+	// A BMC that ignores $expand answers with link-only members, which unmarshal into Sensors
+	// carrying no Id. A partially expanded answer is possible too, so every member is checked
+	// rather than only the first.
+	expanded := make([]*schemas.Sensor, 0, len(agg.Members))
+	for _, member := range agg.Members {
+		if member != nil && member.ID != "" {
+			expanded = append(expanded, member)
+		}
+	}
+	if skipped := len(agg.Members) - len(expanded); skipped > 0 {
+		logger.Warn("BMC did not honour $expand on Sensors; skipping the unexpanded members",
+			slog.String("sensors", sensorsPath),
+			slog.Int("skipped", skipped),
+			slog.Int("collected", len(expanded)),
+		)
+	}
+	return expanded
 }
 
 // getLeakDetectors works around an unfortunate fact that the LeakDetection schema is not yet standard, and some OEMs return
@@ -546,6 +586,47 @@ func parseChassisTemperature(ch chan<- prometheus.Metric, chassisID string, chas
 	ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_temperature_celsius"].desc, prometheus.GaugeValue, gofish.Deref(chassisTemperature.ReadingCelsius), chassisTemperatureLabelvalues...)
 }
 
+// fanUnitLabel normalises a fan's reading unit into the fan_unit label, shared by the Thermal
+// and the Sensors path.
+//
+// The two schemas spell the same unit differently — Thermal's enum gives "RPM" and "Percent",
+// a Sensor gives "%" for the same duty cycle — and fan_unit is part of the fan series
+// identity, so leaving each path to lowercase its own spelling would split one fan's series
+// in two across the platforms that report it either way.
+func fanUnitLabel(units string) string {
+	switch strings.ToLower(units) {
+	case "%", "percent", "percentage":
+		return "percent"
+	case "rpm", "{rev}/min":
+		// Redfish prefers "{rev}/min" for Rotational and deprecates "RPM"; no captured
+		// platform uses it yet, but it must not arrive as a second fan_unit spelling.
+		return "rpm"
+	}
+	return strings.ToLower(units)
+}
+
+// fanPercentage derives a fan's duty cycle from a tachometer reading, shared by the Thermal
+// and the Sensors path so the two cannot drift apart: a platform moving between them must
+// not shift the series under the existing alerts.
+//
+// alreadyPercent covers a fan reporting a duty cycle directly, which needs no derivation.
+//
+// Otherwise the quirks are deliberate. Some vendors (e.g. PowerEdge C6420) report null
+// Min/Max and Lower/UpperFatal but do provide Lower/UpperCritical, so the largest non-null
+// upper bound stands in for a max the firmware did not report. A null min is indistinguishable
+// from a real zero once gofish has flattened it, so it is taken at face value — which is why
+// the formula is (reading + min) / max rather than the usual (reading - min) / (max - min).
+func fanPercentage(reading, rangeMin, rangeMax, upperFatal, upperCritical float64, alreadyPercent bool) float64 {
+	if alreadyPercent {
+		return reading
+	}
+	ceiling := math.Max(math.Max(rangeMax, upperFatal), upperCritical)
+	if ceiling == 0 {
+		return 0
+	}
+	return ((reading + rangeMin) / ceiling) * 100
+}
+
 func parseChassisFan(ch chan<- prometheus.Metric, chassisID string, chassisFan schemas.ThermalFan) {
 	chassisFanID := chassisFan.MemberID
 	chassisFanName := chassisFan.Name
@@ -561,22 +642,17 @@ func parseChassisFan(ch chan<- prometheus.Metric, chassisID string, chassisFan s
 	chassisFanRPMMin := intPtrToFloat64(chassisFan.MinReadingRange)
 	chassisFanRPMMax := intPtrToFloat64(chassisFan.MaxReadingRange)
 
-	chassisFanPercentage := chassisFanRPM
-	if chassisFanUnit != schemas.PercentReadingUnits {
-		// Some vendors (e.g. PowerEdge C6420) report null RPMs for Min/Max, as well as Lower/UpperFatal,
-		// but provide Lower/UpperCritical, so use largest non-null for max. However, we can't know if
-		// min is null (reported as zero by gofish) or just zero, so we'll have to assume a min of zero
-		// if Min is not reported...
-		min := chassisFanRPMMin
-		max := math.Max(math.Max(chassisFanRPMMax, chassisFanRPMUpperFatalThreshold), chassisFanRPMUpperCriticalThreshold)
-		chassisFanPercentage = 0
-		if max != 0 {
-			chassisFanPercentage = float64((chassisFanRPM+min)/max) * 100
-		}
-	}
+	chassisFanPercentage := fanPercentage(
+		chassisFanRPM,
+		chassisFanRPMMin,
+		chassisFanRPMMax,
+		chassisFanRPMUpperFatalThreshold,
+		chassisFanRPMUpperCriticalThreshold,
+		chassisFanUnit == schemas.PercentReadingUnits,
+	)
 
 	//			chassisFanStatusLabelNames :=[]string{BaseLabelNames,"fan_name","fan_member_id")
-	chassisFanLabelvalues := []string{"fan", chassisID, chassisFanName, chassisFanID, strings.ToLower(string(chassisFanUnit))} // e.g. RPM -> rpm, Percentage -> percentage
+	chassisFanLabelvalues := []string{"fan", chassisID, chassisFanName, chassisFanID, fanUnitLabel(string(chassisFanUnit))} // e.g. RPM -> rpm, Percent -> percent
 
 	if chassisFanStausHealthValue, ok := parseCommonStatusHealth(chassisFanStausHealth); ok {
 		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_health"].desc, prometheus.GaugeValue, chassisFanStausHealthValue, chassisFanLabelvalues...)
@@ -604,21 +680,15 @@ func parseLeakDetector(ch chan<- prometheus.Metric, chassisID string, ld *schema
 	}
 }
 
-// thresholdReading flattens an optional Redfish threshold, reporting whether the firmware
-// supplied one at all.
-func thresholdReading(t schemas.Threshold) (float64, bool) {
-	if t.Reading == nil {
-		return 0, false
-	}
-	return *t.Reading, true
-}
-
-// thresholdReadingOrZero is thresholdReading for the fan families, where the Thermal path
-// has always emitted an unreported threshold as zero and the existing alerts compare the
-// two series directly. A Sensors-only platform must produce the same shape.
+// thresholdReadingOrZero flattens an optional Redfish threshold, reporting a threshold the
+// firmware did not supply as zero rather than omitting the series: the Thermal path has
+// always emitted it that way and the existing alerts compare the two series directly, so a
+// Sensors-only platform has to produce the same shape.
 func thresholdReadingOrZero(t schemas.Threshold) float64 {
-	value, _ := thresholdReading(t)
-	return value
+	if t.Reading == nil {
+		return 0
+	}
+	return *t.Reading
 }
 
 // parseChassisSensor emits metrics for a single Sensor resource.
@@ -649,26 +719,22 @@ func parseChassisSensor(ch chan<- prometheus.Metric, chassisID string, sensor *s
 		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_temperature_celsius"].desc, prometheus.GaugeValue, reading, labelValues...)
 
 	case schemas.RotationalReadingType:
-		// A rotational reading is a fan tachometer. Percentage is derived the same way
-		// parseChassisFan derives it — including its quirks: the reading is already a
-		// percentage when that is the unit, the upper thresholds stand in for a max the
-		// firmware did not report, and the formula is (reading + min) / max rather than
-		// the usual (reading - min) / (max - min). Reproducing it exactly is the point,
-		// so a platform that moved from Thermal to Sensors does not shift the series.
-		labelValues := []string{"fan", chassisID, sensor.Name, sensor.ID, strings.ToLower(sensor.ReadingUnits)}
+		// A rotational reading is a fan tachometer, so it goes through the same derivation
+		// the Thermal path uses, quirks and all — see fanPercentage.
+		labelValues := []string{"fan", chassisID, sensor.Name, sensor.ID, fanUnitLabel(sensor.ReadingUnits)}
 		rpmMin := gofish.Deref(sensor.ReadingRangeMin)
 		rpmMax := gofish.Deref(sensor.ReadingRangeMax)
-		// Thermal spells this unit "Percent" and Sensors spells it "%"; accept either, so
-		// that a firmware using the Thermal spelling in a Sensor is not scaled twice.
-		percentage := reading
-		if !strings.EqualFold(sensor.ReadingUnits, "%") && !strings.EqualFold(sensor.ReadingUnits, string(schemas.PercentReadingUnits)) {
-			upper := math.Max(thresholdReadingOrZero(sensor.Thresholds.UpperFatal), thresholdReadingOrZero(sensor.Thresholds.UpperCritical))
-			max := math.Max(rpmMax, upper)
-			percentage = 0
-			if max != 0 {
-				percentage = ((reading + rpmMin) / max) * 100
-			}
-		}
+		// Thermal spells this unit "Percent" and Sensors spells it "%"; fanUnitLabel accepts
+		// either, so a firmware using the Thermal spelling in a Sensor is not scaled twice.
+		alreadyPercent := fanUnitLabel(sensor.ReadingUnits) == "percent"
+		percentage := fanPercentage(
+			reading,
+			rpmMin,
+			rpmMax,
+			thresholdReadingOrZero(sensor.Thresholds.UpperFatal),
+			thresholdReadingOrZero(sensor.Thresholds.UpperCritical),
+			alreadyPercent,
+		)
 		if health, ok := parseCommonStatusHealth(sensor.Status.Health); ok {
 			ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_health"].desc, prometheus.GaugeValue, health, labelValues...)
 		}

--- a/internal/collector/chassis_collector.go
+++ b/internal/collector/chassis_collector.go
@@ -2,7 +2,9 @@ package collector
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"math"
 	"strings"
@@ -27,6 +29,7 @@ var (
 	ChassisNetworkPortLabelNames      = []string{"resource", "chassis_id", "network_adapter", "network_adapter_id", "network_port", "network_port_id", "network_port_type", "network_port_speed", "network_port_connectiont_type", "network_physical_port_number"}
 	ChassisPhysicalSecurityLabelNames = []string{"resource", "chassis_id", "intrusion_sensor_number", "intrusion_sensor_rearm"}
 	ChassisLeakDetectorLabelNames     = []string{"resource", "chassis_id", "leak_detection_id", "leak_detector_id"}
+	ChassisSensorLabelNames           = []string{"resource", "chassis_id", "sensor", "sensor_id", "sensor_units", "physical_context"}
 
 	ChassisLogServiceLabelNames = []string{"chassis_id", "log_service", "log_service_id", "log_service_enabled", "log_service_overwrite_policy"}
 
@@ -90,6 +93,18 @@ func createChassisMetricMap() map[string]Metric {
 	addToMetricMap(chassisMetrics, ChassisSubsystem, "log_service_health_state", fmt.Sprintf("chassis log service health state,%s", CommonHealthHelp), ChassisLogServiceLabelNames)
 
 	addToMetricMap(chassisMetrics, ChassisSubsystem, "leak_detector_health", fmt.Sprintf("chassis leak detector health state,%s", CommonHealthHelp), ChassisLeakDetectorLabelNames)
+
+	// Catch-all for Sensors whose ReadingType has no equivalent among the families above,
+	// so a reading is never silently dropped. Unambiguous ones fold into those families
+	// instead; see parseChassisSensor.
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "sensor_watts", "chassis sensor reading in watts", ChassisSensorLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "sensor_amperes", "chassis sensor reading in amperes", ChassisSensorLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "sensor_joules", "chassis sensor reading in joules", ChassisSensorLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "sensor_hertz", "chassis sensor reading in hertz", ChassisSensorLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "sensor_percent", "chassis sensor reading as a percentage", ChassisSensorLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "sensor_reading", fmt.Sprintf("chassis sensor reading for a reading type with no dedicated metric; the units are in the %q label", "sensor_units"), ChassisSensorLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "sensor_health", fmt.Sprintf("chassis sensor health,%s", CommonHealthHelp), ChassisSensorLabelNames)
+	addToMetricMap(chassisMetrics, ChassisSubsystem, "sensor_state", fmt.Sprintf("chassis sensor state,%s", CommonStateHelp), ChassisSensorLabelNames)
 
 	// Note: chassis_gpu_total_power_watts is now collected via TelemetryService (HGX_PlatformEnvironmentMetrics_0)
 
@@ -178,6 +193,13 @@ func (c *ChassisCollector) collect(ctx context.Context, ch chan<- prometheus.Met
 		ChassisModelLabelValues := []string{"chassis", chassisID, chassisManufacturer, chassisModel, chassisPartNumber, chassisSKU}
 		ch <- prometheus.MustNewConstMetric(c.metrics["chassis_model_info"].desc, prometheus.GaugeValue, 1, ChassisModelLabelValues...)
 
+		// The subordinate resources this chassis actually advertises. Newer platforms
+		// (for example an NVL72 tray, where no chassis implements Thermal or Power)
+		// express the same readings through Sensors instead, which is collected below
+		// only when the legacy schemas are absent so the two paths never emit duplicate
+		// series.
+		links := chassisAdvertisedLinks(chassis)
+
 		chassisThermal, err := chassis.Thermal()
 		if err != nil {
 			chassisLogger.Error("error getting thermal data from chassis", slog.String("operation", "chassis.Thermal()"), slog.Any("error", err))
@@ -204,6 +226,13 @@ func (c *ChassisCollector) collect(ctx context.Context, ch chan<- prometheus.Met
 				chassisLogger.Error("goroutine error", slog.Any("error", err))
 			}
 		}
+		// leakDetectorIDs is the Id of every leak detector on this chassis. Each detector is
+		// dual-surfaced: the LeakDetector resource carries the discrete state, while a
+		// Sensor of the same Id carries an analog voltage. The Sensors pass below uses this
+		// to leave those readings alone rather than publishing them as ordinary chassis
+		// voltages, which is what they would otherwise be mistaken for.
+		leakDetectorIDs := map[string]struct{}{}
+
 		chassisThermalSubsystem, err := chassis.ThermalSubsystem()
 		if err != nil {
 			chassisLogger.Error("error getting thermal subsystem from chassis", slog.String("operation", "chassis.ThermalSubsystem()"), slog.Any("error", err))
@@ -212,6 +241,10 @@ func (c *ChassisCollector) collect(ctx context.Context, ch chan<- prometheus.Met
 		} else {
 			// NOTE: Handles some odd (maybe even buggy) OEM implementations of LeakDeteactor
 			leakDetectors := c.getLeakDetectors(chassisThermalSubsystem, chassisLogger)
+
+			for _, ld := range leakDetectors {
+				leakDetectorIDs[ld.ID] = struct{}{}
+			}
 
 			if len(leakDetectors) > 0 {
 				egLD := newRecoverGroup(ctx)
@@ -265,6 +298,37 @@ func (c *ChassisCollector) collect(ctx context.Context, ch chan<- prometheus.Met
 			}
 		}
 
+		// The Sensors collection stands in for Thermal and Power on platforms that
+		// implement neither, so it is consulted only when both are absent. Collecting it
+		// alongside them would publish a chassis's temperatures twice under one series
+		// name, failing the scrape at registration.
+		if !links.legacyThermalOrPower() {
+			sensorsPath := links.sensorsPath(chassis)
+			sensors, err := c.getChassisSensors(ctx, sensorsPath, chassisLogger)
+			if err != nil {
+				chassisLogger.Error("error getting sensors from chassis", slog.String("operation", "chassis.Sensors()"), slog.Any("error", err))
+			} else if len(sensors) == 0 {
+				chassisLogger.Debug("no sensors found", slog.String("operation", "chassis.Sensors()"))
+			} else {
+				// Parsing a sensor is a handful of channel sends, so this stays a plain
+				// loop; a goroutine per sensor would be several hundred per tray to save
+				// nothing.
+				for _, sensor := range sensors {
+					if sensor == nil {
+						continue
+					}
+					// A leak detector's companion sensor is a leak signal, not a chassis
+					// voltage, and publishing it as one would misreport it. It is left to
+					// the leak detection path, which is the only thing able to interpret
+					// it against its thresholds.
+					if _, isLeakDetector := leakDetectorIDs[sensor.ID]; isLeakDetector {
+						continue
+					}
+					parseChassisSensor(ch, chassisID, sensor)
+				}
+			}
+		}
+
 		// process NetworkAdapter
 		networkAdapters, err := chassis.NetworkAdapters()
 		if err != nil {
@@ -308,6 +372,115 @@ func (c *ChassisCollector) Describe(ch chan<- *prometheus.Desc) {
 	}
 	c.collectorScrapeStatus.Describe(ch)
 
+}
+
+// sensorCollection is the shape of an expanded Sensors collection response. Members are
+// full Sensor bodies rather than links, so one request replaces one-per-sensor.
+type sensorCollection struct {
+	Members []*schemas.Sensor `json:"Members"`
+}
+
+// chassisLinks are the subordinate resource URIs advertised by a chassis payload.
+//
+// gofish parses the same links but keeps them unexported, so they are re-read from the raw
+// payload here. Reading the advertised links rather than inferring from a fetch means the
+// answers do not change when a subsystem is disabled by configuration, and that a resource
+// the chassis never advertises is never requested.
+type chassisLinks struct {
+	thermal string
+	power   string
+	sensors string
+	// opaque records that the payload could not be inspected at all, which every field
+	// being empty would otherwise be indistinguishable from.
+	opaque bool
+}
+
+// chassisAdvertisedLinks extracts the links this collector decides on from a chassis.
+func chassisAdvertisedLinks(chassis *schemas.Chassis) chassisLinks {
+	if len(chassis.RawData) == 0 {
+		return chassisLinks{opaque: true}
+	}
+	var raw struct {
+		Thermal odataLink `json:"Thermal"`
+		Power   odataLink `json:"Power"`
+		Sensors odataLink `json:"Sensors"`
+	}
+	if err := json.Unmarshal(chassis.RawData, &raw); err != nil {
+		return chassisLinks{opaque: true}
+	}
+	return chassisLinks{
+		thermal: raw.Thermal.ODataID,
+		power:   raw.Power.ODataID,
+		sensors: raw.Sensors.ODataID,
+	}
+}
+
+// legacyThermalOrPower reports whether the chassis links either of the deprecated Thermal
+// or Power resources.
+//
+// An uninspectable payload counts as advertising them, suppressing the Sensors fallback
+// rather than risking a wasted request per chassis.
+//
+// Either link suppresses it, not both: a chassis implementing exactly one and expressing the
+// other half only through Sensors would lose that half. None does in any captured payload,
+// and the alternative risks duplicate series, which fails the scrape rather than thinning it.
+func (l chassisLinks) legacyThermalOrPower() bool {
+	return l.opaque || l.thermal != "" || l.power != ""
+}
+
+// sensorsPath returns the advertised Sensors collection URI, or "" when this chassis has
+// no Sensors resource to request.
+//
+// Synthesising "<chassis>/Sensors" instead would 404 once per scrape on every chassis that
+// has none, which is roughly a third of an NVL72 tray or HGX baseboard (the ERoT/IRoT
+// roots). An opaque payload falls back to the conventional path.
+func (l chassisLinks) sensorsPath(chassis *schemas.Chassis) string {
+	if l.opaque {
+		return chassis.ODataID + "/Sensors"
+	}
+	return l.sensors
+}
+
+// getChassisSensors returns sensors for a chassis in a single request, using $expand so the
+// BMC inlines every member body rather than gofish's one request per member.
+//
+// If the BMC does not honour $expand there is deliberately no fan-out to one request per
+// sensor: that would multiply request count against the BMCs least able to absorb it. The
+// bulk sensor telemetry is skipped with a warning instead.
+func (c *ChassisCollector) getChassisSensors(ctx context.Context, sensorsPath string, logger *slog.Logger) ([]*schemas.Sensor, error) {
+	if sensorsPath == "" {
+		return nil, nil
+	}
+	rfClient := c.redfishClient.WithContext(ctx)
+
+	response, err := rfClient.Get(sensorsPath + `?$expand=.($levels=1)`)
+	if err != nil {
+		logger.Debug("expanded Sensors request failed", slog.Any("error", err))
+		return nil, nil
+	}
+	defer response.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var agg sensorCollection
+	if err := json.Unmarshal(body, &agg); err != nil {
+		return nil, err
+	}
+	// A BMC that ignores $expand answers with link-only members, which unmarshal into
+	// Sensors carrying no Id.
+	if len(agg.Members) > 0 && agg.Members[0] != nil && agg.Members[0].ID != "" {
+		return agg.Members, nil
+	}
+	if len(agg.Members) > 0 {
+		logger.Warn("BMC did not honour $expand on Sensors; skipping bulk sensor collection",
+			slog.String("sensors", sensorsPath),
+			slog.Int("skipped", len(agg.Members)),
+		)
+	}
+	return nil, nil
 }
 
 // getLeakDetectors works around an unfortunate fact that the LeakDetection schema is not yet standard, and some OEMs return
@@ -429,6 +602,125 @@ func parseLeakDetector(ch chan<- prometheus.Metric, chassisID string, ld *schema
 	if statusHealth, ok := parseCommonStatusHealth(ld.Status.Health); ok {
 		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_leak_detector_health"].desc, prometheus.GaugeValue, statusHealth, labelValues...)
 	}
+}
+
+// thresholdReading flattens an optional Redfish threshold, reporting whether the firmware
+// supplied one at all.
+func thresholdReading(t schemas.Threshold) (float64, bool) {
+	if t.Reading == nil {
+		return 0, false
+	}
+	return *t.Reading, true
+}
+
+// thresholdReadingOrZero is thresholdReading for the fan families, where the Thermal path
+// has always emitted an unreported threshold as zero and the existing alerts compare the
+// two series directly. A Sensors-only platform must produce the same shape.
+func thresholdReadingOrZero(t schemas.Threshold) float64 {
+	value, _ := thresholdReading(t)
+	return value
+}
+
+// parseChassisSensor emits metrics for a single Sensor resource.
+//
+// An unambiguous ReadingType folds into the existing chassis metric family so that a
+// Sensors-only platform produces the same series names as a Thermal/Power one; anything
+// else lands in a sensor_* catch-all rather than being guessed at or dropped.
+//
+// Readings are deliberately not inferred from sensor naming. On an NVL72 tray, fan PWM duty
+// cycle and CPU core utilisation are both ReadingType "Percent" and neither carries a
+// distinguishing PhysicalContext, so treating "Percent" as a fan speed would mislabel over
+// a hundred sensors per tray.
+func parseChassisSensor(ch chan<- prometheus.Metric, chassisID string, sensor *schemas.Sensor) {
+	if sensor == nil || sensor.ID == "" {
+		return
+	}
+	reading := gofish.Deref(sensor.Reading)
+
+	switch sensor.ReadingType {
+	case schemas.TemperatureReadingType:
+		labelValues := []string{"temperature", chassisID, sensor.Name, sensor.ID}
+		if health, ok := parseCommonStatusHealth(sensor.Status.Health); ok {
+			ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_temperature_sensor_health"].desc, prometheus.GaugeValue, health, labelValues...)
+		}
+		if state, ok := parseCommonStatusState(sensor.Status.State); ok {
+			ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_temperature_sensor_state"].desc, prometheus.GaugeValue, state, labelValues...)
+		}
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_temperature_celsius"].desc, prometheus.GaugeValue, reading, labelValues...)
+
+	case schemas.RotationalReadingType:
+		// A rotational reading is a fan tachometer. Percentage is derived the same way
+		// parseChassisFan derives it — including its quirks: the reading is already a
+		// percentage when that is the unit, the upper thresholds stand in for a max the
+		// firmware did not report, and the formula is (reading + min) / max rather than
+		// the usual (reading - min) / (max - min). Reproducing it exactly is the point,
+		// so a platform that moved from Thermal to Sensors does not shift the series.
+		labelValues := []string{"fan", chassisID, sensor.Name, sensor.ID, strings.ToLower(sensor.ReadingUnits)}
+		rpmMin := gofish.Deref(sensor.ReadingRangeMin)
+		rpmMax := gofish.Deref(sensor.ReadingRangeMax)
+		// Thermal spells this unit "Percent" and Sensors spells it "%"; accept either, so
+		// that a firmware using the Thermal spelling in a Sensor is not scaled twice.
+		percentage := reading
+		if !strings.EqualFold(sensor.ReadingUnits, "%") && !strings.EqualFold(sensor.ReadingUnits, string(schemas.PercentReadingUnits)) {
+			upper := math.Max(thresholdReadingOrZero(sensor.Thresholds.UpperFatal), thresholdReadingOrZero(sensor.Thresholds.UpperCritical))
+			max := math.Max(rpmMax, upper)
+			percentage = 0
+			if max != 0 {
+				percentage = ((reading + rpmMin) / max) * 100
+			}
+		}
+		if health, ok := parseCommonStatusHealth(sensor.Status.Health); ok {
+			ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_health"].desc, prometheus.GaugeValue, health, labelValues...)
+		}
+		if state, ok := parseCommonStatusState(sensor.Status.State); ok {
+			ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_state"].desc, prometheus.GaugeValue, state, labelValues...)
+		}
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_rpm"].desc, prometheus.GaugeValue, reading, labelValues...)
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_rpm_min"].desc, prometheus.GaugeValue, rpmMin, labelValues...)
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_rpm_max"].desc, prometheus.GaugeValue, rpmMax, labelValues...)
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_rpm_percentage"].desc, prometheus.GaugeValue, percentage, labelValues...)
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_rpm_lower_threshold_critical"].desc, prometheus.GaugeValue, thresholdReadingOrZero(sensor.Thresholds.LowerCritical), labelValues...)
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_rpm_upper_threshold_critical"].desc, prometheus.GaugeValue, thresholdReadingOrZero(sensor.Thresholds.UpperCritical), labelValues...)
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_rpm_lower_threshold_fatal"].desc, prometheus.GaugeValue, thresholdReadingOrZero(sensor.Thresholds.LowerFatal), labelValues...)
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_fan_rpm_upper_threshold_fatal"].desc, prometheus.GaugeValue, thresholdReadingOrZero(sensor.Thresholds.UpperFatal), labelValues...)
+
+	case schemas.VoltageReadingType:
+		labelValues := []string{"power_voltage", chassisID, sensor.Name, sensor.ID}
+		if state, ok := parseCommonStatusState(sensor.Status.State); ok {
+			ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_power_voltage_state"].desc, prometheus.GaugeValue, state, labelValues...)
+		}
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_power_voltage_volts"].desc, prometheus.GaugeValue, reading, labelValues...)
+
+	default:
+		parseChassisSensorCatchall(ch, chassisID, sensor, reading)
+	}
+}
+
+// parseChassisSensorCatchall emits a sensor whose ReadingType has no curated equivalent.
+func parseChassisSensorCatchall(ch chan<- prometheus.Metric, chassisID string, sensor *schemas.Sensor, reading float64) {
+	labelValues := []string{"sensor", chassisID, sensor.Name, sensor.ID, sensor.ReadingUnits, string(sensor.PhysicalContext)}
+
+	metricKey := "chassis_sensor_reading"
+	switch sensor.ReadingType {
+	case schemas.PowerReadingType:
+		metricKey = "chassis_sensor_watts"
+	case schemas.CurrentReadingType:
+		metricKey = "chassis_sensor_amperes"
+	case schemas.EnergyJoulesReadingType:
+		metricKey = "chassis_sensor_joules"
+	case schemas.FrequencyReadingType:
+		metricKey = "chassis_sensor_hertz"
+	case schemas.PercentReadingType:
+		metricKey = "chassis_sensor_percent"
+	}
+
+	if health, ok := parseCommonStatusHealth(sensor.Status.Health); ok {
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_sensor_health"].desc, prometheus.GaugeValue, health, labelValues...)
+	}
+	if state, ok := parseCommonStatusState(sensor.Status.State); ok {
+		ch <- prometheus.MustNewConstMetric(chassisMetrics["chassis_sensor_state"].desc, prometheus.GaugeValue, state, labelValues...)
+	}
+	ch <- prometheus.MustNewConstMetric(chassisMetrics[metricKey].desc, prometheus.GaugeValue, reading, labelValues...)
 }
 
 func parseChassisPowerInfoVoltage(ch chan<- prometheus.Metric, chassisID string, chassisPowerInfoVoltage schemas.Voltage) {

--- a/internal/collector/chassis_collector_test.go
+++ b/internal/collector/chassis_collector_test.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"maps"
@@ -15,6 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stmcginnis/gofish"
+	"github.com/stmcginnis/gofish/schemas"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,8 +57,6 @@ func drainMetrics(t *testing.T, ch chan prometheus.Metric) map[string][]collecte
 }
 
 // requireMetric asserts exactly one sample exists for name and returns it.
-//
-//nolint:unused // part of the drainMetrics harness; its first callers land with the Sensors and telemetry tests.
 func requireMetric(t *testing.T, metrics map[string][]collectedMetric, name string) collectedMetric {
 	t.Helper()
 	samples, ok := metrics[name]
@@ -101,6 +101,340 @@ func TestCollectSurvivesOneUnreachableChassis(t *testing.T) {
 	health := metrics["redfish_chassis_health"]
 	require.Len(t, health, 1, "the healthy chassis must still be collected")
 	require.Equal(t, "Chassis_0", health[0].labels["chassis_id"])
+}
+
+func TestGetChassisSensorsUsesExpand(t *testing.T) {
+	server := newTestRedfishServer(t)
+	server.addRouteFromFixture("/redfish/v1/Chassis", "chassis_collection.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0", "chassis_main.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/Sensors", "chassis_sensors_expanded.json")
+
+	var expandedRequests int
+	server.mux.HandleFunc("/redfish/v1/Chassis/Chassis_0/Sensors/", func(w http.ResponseWriter, r *http.Request) {
+		expandedRequests++
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	client := connectToTestServer(t, server.Server)
+	t.Cleanup(func() {
+		client.Logout()
+		server.Close()
+	})
+
+	chassis, err := client.GetService().Chassis()
+	require.NoError(t, err)
+
+	collector, err := NewChassisCollector(t.Name(), client, NewTestLogger(t, slog.LevelDebug), config.DefaultChassisCollector)
+	require.NoError(t, err)
+
+	links := chassisAdvertisedLinks(chassis[0])
+	sensors, err := collector.getChassisSensors(context.Background(), links.sensorsPath(chassis[0]), NewTestLogger(t, slog.LevelDebug))
+	require.NoError(t, err)
+	require.Len(t, sensors, 6, "all sensors should arrive from the single expanded request")
+	require.Zero(t, expandedRequests, "no per-sensor requests should be issued when $expand is honoured")
+}
+
+// TestGetChassisSensorsSkipsChassisWithoutSensors covers the ERoT/IRoT chassis that make up
+// roughly a third of an NVL72 tray or HGX baseboard: they advertise no Sensors collection,
+// and synthesising "<chassis>/Sensors" for them cost a 404 on every scrape.
+func TestGetChassisSensorsSkipsChassisWithoutSensors(t *testing.T) {
+	server := newTestRedfishServer(t)
+	server.addRoute("/redfish/v1/Chassis", map[string]any{
+		"@odata.id":   "/redfish/v1/Chassis",
+		"@odata.type": "#ChassisCollection.ChassisCollection",
+		"Members": []map[string]string{
+			{"@odata.id": "/redfish/v1/Chassis/HGX_ERoT_NVSwitch_0"},
+		},
+	})
+	// A real ERoT root: no Thermal, no Power, and no Sensors either.
+	server.addRoute("/redfish/v1/Chassis/HGX_ERoT_NVSwitch_0", map[string]any{
+		"@odata.id":   "/redfish/v1/Chassis/HGX_ERoT_NVSwitch_0",
+		"@odata.type": "#Chassis.v1_22_0.Chassis",
+		"Id":          "HGX_ERoT_NVSwitch_0",
+		"ChassisType": "Component",
+		"Status":      map[string]any{"Health": "OK", "State": "Enabled"},
+	})
+
+	var sensorRequests int
+	server.mux.HandleFunc("/redfish/v1/Chassis/HGX_ERoT_NVSwitch_0/Sensors", func(w http.ResponseWriter, r *http.Request) {
+		sensorRequests++
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	client := connectToTestServer(t, server.Server)
+	t.Cleanup(func() {
+		client.Logout()
+		server.Close()
+	})
+
+	collector, err := NewChassisCollector(t.Name(), client, NewTestLogger(t, slog.LevelDebug), config.DefaultChassisCollector)
+	require.NoError(t, err)
+
+	ch := make(chan prometheus.Metric, 64)
+	collector.CollectWithContext(context.Background(), ch)
+	drainMetrics(t, ch)
+
+	require.Zero(t, sensorRequests, "a chassis advertising no Sensors collection must not be asked for one")
+}
+
+// TestGetChassisSensorsBoundedWhenExpandIgnored covers a BMC that answers the Sensors
+// collection with link-only members. Fanning out to one request per sensor there would
+// multiply request load against the BMCs least able to absorb it, so the bulk telemetry is
+// skipped with a warning instead.
+func TestGetChassisSensorsBoundedWhenExpandIgnored(t *testing.T) {
+	server := newTestRedfishServer(t)
+	server.addRouteFromFixture("/redfish/v1/Chassis", "chassis_collection.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0", "chassis_main.json")
+
+	// Link-only members, as a BMC that ignores $expand would return.
+	server.addRoute("/redfish/v1/Chassis/Chassis_0/Sensors", map[string]any{
+		"@odata.id":           "/redfish/v1/Chassis/Chassis_0/Sensors",
+		"@odata.type":         "#SensorCollection.SensorCollection",
+		"Name":                "Sensor Collection",
+		"Members@odata.count": 3,
+		"Members": []map[string]string{
+			{"@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors/Chassis_0_LeakDetector_0_ColdPlate"},
+			{"@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors/Chassis_0_FAN_1_FRONT"},
+			{"@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors/Chassis_0_Front_IO_Temp_0"},
+		},
+	})
+
+	var perSensorRequests []string
+	for _, id := range []string{"Chassis_0_LeakDetector_0_ColdPlate", "Chassis_0_FAN_1_FRONT", "Chassis_0_Front_IO_Temp_0"} {
+		sensorID := id
+		server.mux.HandleFunc("/redfish/v1/Chassis/Chassis_0/Sensors/"+sensorID, func(w http.ResponseWriter, r *http.Request) {
+			perSensorRequests = append(perSensorRequests, sensorID)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/Chassis/Chassis_0/Sensors/` + sensorID + `","Id":"` + sensorID + `","Name":"` + sensorID + `","ReadingType":"Voltage","Reading":1.7}`))
+		})
+	}
+
+	client := connectToTestServer(t, server.Server)
+	t.Cleanup(func() {
+		client.Logout()
+		server.Close()
+	})
+
+	chassis, err := client.GetService().Chassis()
+	require.NoError(t, err)
+
+	collector, err := NewChassisCollector(t.Name(), client, NewTestLogger(t, slog.LevelDebug), config.DefaultChassisCollector)
+	require.NoError(t, err)
+
+	links := chassisAdvertisedLinks(chassis[0])
+	sensors, err := collector.getChassisSensors(context.Background(), links.sensorsPath(chassis[0]), NewTestLogger(t, slog.LevelDebug))
+	require.NoError(t, err)
+
+	require.Empty(t, sensors, "an unexpanded collection yields no bulk sensors")
+	require.Empty(t, perSensorRequests, "no sensor may be fetched individually")
+}
+
+func TestChassisAdvertisedLinks(t *testing.T) {
+	tT := map[string]struct {
+		raw         string
+		wantLegacy  bool
+		wantSensors string
+	}{
+		"legacy chassis linking Thermal and Power": {
+			raw:        `{"Id":"1","Thermal":{"@odata.id":"/redfish/v1/Chassis/1/Thermal"},"Power":{"@odata.id":"/redfish/v1/Chassis/1/Power"}}`,
+			wantLegacy: true,
+		},
+		"Thermal only": {
+			raw:        `{"Id":"1","Thermal":{"@odata.id":"/redfish/v1/Chassis/1/Thermal"}}`,
+			wantLegacy: true,
+		},
+		// The real ARS-121GL-NB3 tray shelf: ThermalSubsystem and Sensors, no Thermal/Power.
+		"NVL72 tray chassis": {
+			raw:         `{"Id":"Chassis_0","ThermalSubsystem":{"@odata.id":"/redfish/v1/Chassis/Chassis_0/ThermalSubsystem"},"Sensors":{"@odata.id":"/redfish/v1/Chassis/Chassis_0/Sensors"},"PowerSubsystem":{"@odata.id":"/redfish/v1/Chassis/Chassis_0/PowerSubsystem"}}`,
+			wantLegacy:  false,
+			wantSensors: "/redfish/v1/Chassis/Chassis_0/Sensors",
+		},
+		// An ERoT root. No Sensors link means there is no collection to request.
+		"root of trust chassis": {
+			raw:         `{"Id":"HGX_ERoT_NVSwitch_0","@odata.id":"/redfish/v1/Chassis/HGX_ERoT_NVSwitch_0"}`,
+			wantLegacy:  false,
+			wantSensors: "",
+		},
+		"empty link objects do not count": {
+			raw:        `{"Id":"1","Thermal":{},"Power":{},"Sensors":{}}`,
+			wantLegacy: false,
+		},
+	}
+
+	for tName, test := range tT {
+		t.Run(tName, func(t *testing.T) {
+			var chassis schemas.Chassis
+			require.NoError(t, json.Unmarshal([]byte(test.raw), &chassis))
+			links := chassisAdvertisedLinks(&chassis)
+			require.Equal(t, test.wantLegacy, links.legacyThermalOrPower())
+			require.Equal(t, test.wantSensors, links.sensorsPath(&chassis))
+		})
+	}
+
+	// A chassis with no retained payload is treated conservatively as legacy, so the
+	// Sensors fallback is suppressed rather than issuing a request per chassis.
+	opaque := chassisAdvertisedLinks(&schemas.Chassis{})
+	require.True(t, opaque.legacyThermalOrPower())
+	require.Equal(t, "/Sensors", opaque.sensorsPath(&schemas.Chassis{}))
+}
+
+// TestLeakDetectorSensorIsNeverAChassisVoltage pins a safety property that has to hold no
+// matter how leak detection itself evolves: a detector's companion sensor is a Voltage
+// reading like any other, so anything that folds it into the power_voltage family reports a
+// leak signal as a rail measurement.
+//
+// The assertion is deliberately negative rather than "this sensor produces nothing", so it
+// keeps its meaning once the detectors gain a metric family of their own.
+func TestLeakDetectorSensorIsNeverAChassisVoltage(t *testing.T) {
+	server := newTestRedfishServer(t)
+	server.addRouteFromFixture("/redfish/v1/Chassis", "chassis_collection.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0", "chassis_main.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/Sensors", "chassis_sensors_expanded.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem", "thermal_subsystem.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection", "leak_detection.json")
+	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors", "leak_detectors_collection.json")
+	for _, id := range []string{
+		"Chassis_0_LeakDetector_0_ColdPlate",
+		"Chassis_0_LeakDetector_0_Manifold",
+		"Chassis_0_LeakDetector_1_ColdPlate",
+		"Chassis_0_LeakDetector_1_Manifold",
+	} {
+		server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection/LeakDetectors/"+id, "leak_detector_ok.json")
+	}
+
+	client := connectToTestServer(t, server.Server)
+	t.Cleanup(func() {
+		client.Logout()
+		server.Close()
+	})
+
+	collector, err := NewChassisCollector(t.Name(), client, NewTestLogger(t, slog.LevelDebug), config.DefaultChassisCollector)
+	require.NoError(t, err)
+
+	ch := make(chan prometheus.Metric, 512)
+	collector.CollectWithContext(context.Background(), ch)
+	metrics := drainMetrics(t, ch)
+
+	// The rest of the collection still arrives.
+	require.Contains(t, metrics, "redfish_chassis_temperature_celsius")
+	require.Contains(t, metrics, "redfish_chassis_sensor_watts")
+
+	// The detector's voltage does not, under any series name.
+	for _, sample := range metrics["redfish_chassis_power_voltage_volts"] {
+		require.NotContains(t, sample.labels["power_voltage_id"], "LeakDetector",
+			"a leak detector must not be published as a chassis power voltage")
+	}
+	for name, samples := range metrics {
+		for _, sample := range samples {
+			for _, label := range []string{"sensor_id", "power_voltage_id"} {
+				require.NotContains(t, sample.labels[label], "LeakDetector",
+					"leak detector %q leaked into %s", sample.labels[label], name)
+			}
+		}
+	}
+}
+
+func TestParseChassisSensor(t *testing.T) {
+	var collection sensorCollection
+	loadTestDataInto(t, "chassis_sensors_expanded.json", &collection)
+	require.Len(t, collection.Members, 6)
+
+	byID := map[string]*schemas.Sensor{}
+	for _, sensor := range collection.Members {
+		byID[sensor.ID] = sensor
+	}
+
+	t.Run("temperature folds into the existing chassis family", func(t *testing.T) {
+		ch := make(chan prometheus.Metric, 32)
+		parseChassisSensor(ch, "Chassis_0", byID["Chassis_0_Front_IO_Temp_0"])
+		metrics := drainMetrics(t, ch)
+
+		celsius := requireMetric(t, metrics, "redfish_chassis_temperature_celsius")
+		require.InDelta(t, 27.5, celsius.value, 1e-9)
+		require.Equal(t, "temperature", celsius.labels["resource"])
+		require.Equal(t, "Chassis 0 Front IO Temp 0", celsius.labels["sensor"])
+		require.Equal(t, "Chassis_0_Front_IO_Temp_0", celsius.labels["sensor_id"])
+		require.Equal(t, float64(1), requireMetric(t, metrics, "redfish_chassis_temperature_sensor_health").value)
+	})
+
+	t.Run("rotational folds into the existing fan family with thresholds", func(t *testing.T) {
+		ch := make(chan prometheus.Metric, 32)
+		parseChassisSensor(ch, "Chassis_0", byID["Chassis_0_FAN_1_FRONT"])
+		metrics := drainMetrics(t, ch)
+
+		rpm := requireMetric(t, metrics, "redfish_chassis_fan_rpm")
+		require.InDelta(t, 8623.0, rpm.value, 1e-9)
+		require.Equal(t, "fan", rpm.labels["resource"])
+		require.Equal(t, "rpm", rpm.labels["fan_unit"])
+
+		// The existing ChassisFanCritical alert compares these two series directly, so a
+		// Sensors-only platform must populate both for that alert to work there.
+		require.InDelta(t, 2204.0, requireMetric(t, metrics, "redfish_chassis_fan_rpm_lower_threshold_critical").value, 1e-9)
+		require.InDelta(t, 23.056, requireMetric(t, metrics, "redfish_chassis_fan_rpm_percentage").value, 0.001)
+	})
+
+	// parseChassisFan has always handled two cases beyond a plain RPM range, and the
+	// Sensors path has to reach the same numbers or a platform moving from Thermal to
+	// Sensors would shift the series under the existing alerts.
+	t.Run("rotational percentage matches the thermal path in its awkward cases", func(t *testing.T) {
+		reading := 50.0
+		max := 20000.0
+
+		t.Run("a reading already in percent is used as-is", func(t *testing.T) {
+			ch := make(chan prometheus.Metric, 32)
+			parseChassisSensor(ch, "Chassis_0", &schemas.Sensor{
+				Entity:       schemas.Entity{ID: "FAN_PCT", Name: "FAN_PCT"},
+				ReadingType:  schemas.RotationalReadingType,
+				ReadingUnits: "%",
+				Reading:      &reading,
+			})
+			metrics := drainMetrics(t, ch)
+			require.InDelta(t, 50.0, requireMetric(t, metrics, "redfish_chassis_fan_rpm_percentage").value, 1e-9)
+		})
+
+		// Some vendors report null Min/Max but do supply the upper thresholds, so those
+		// stand in for the max rather than leaving the percentage stuck at zero.
+		t.Run("an absent max falls back to the upper thresholds", func(t *testing.T) {
+			ch := make(chan prometheus.Metric, 32)
+			parseChassisSensor(ch, "Chassis_0", &schemas.Sensor{
+				Entity:      schemas.Entity{ID: "FAN_NORANGE", Name: "FAN_NORANGE"},
+				ReadingType: schemas.RotationalReadingType,
+				Reading:     &reading,
+				Thresholds:  schemas.Thresholds{UpperCritical: schemas.Threshold{Reading: &max}},
+			})
+			metrics := drainMetrics(t, ch)
+			require.InDelta(t, 0.25, requireMetric(t, metrics, "redfish_chassis_fan_rpm_percentage").value, 1e-9)
+		})
+	})
+
+	// Fan PWM duty cycle and CPU core utilisation are both ReadingType "Percent" and
+	// neither carries a distinguishing PhysicalContext, so Percent must not be assumed
+	// to be a fan speed.
+	t.Run("percent is not assumed to be a fan speed", func(t *testing.T) {
+		ch := make(chan prometheus.Metric, 32)
+		parseChassisSensor(ch, "Chassis_0", byID["Chassis_0_FAN_1_PWM"])
+		metrics := drainMetrics(t, ch)
+
+		require.NotContains(t, metrics, "redfish_chassis_fan_rpm_percentage")
+		percent := requireMetric(t, metrics, "redfish_chassis_sensor_percent")
+		require.InDelta(t, 29.803921, percent.value, 1e-5)
+		require.Equal(t, "%", percent.labels["sensor_units"])
+	})
+
+	t.Run("power and unrecognised reading types reach a catch-all", func(t *testing.T) {
+		ch := make(chan prometheus.Metric, 32)
+		parseChassisSensor(ch, "Chassis_0", byID["Chassis_0_TotalHSC_Power_0"])
+		metrics := drainMetrics(t, ch)
+		require.InDelta(t, 1171.349692, requireMetric(t, metrics, "redfish_chassis_sensor_watts").value, 1e-6)
+
+		// Altitude has no dedicated metric; it must still be emitted rather than dropped.
+		ch = make(chan prometheus.Metric, 32)
+		parseChassisSensor(ch, "Chassis_0", byID["Chassis_0_Altitude_0"])
+		metrics = drainMetrics(t, ch)
+		reading := requireMetric(t, metrics, "redfish_chassis_sensor_reading")
+		require.InDelta(t, 132.0, reading.value, 1e-9)
+		require.Equal(t, "m", reading.labels["sensor_units"])
+	})
 }
 
 func TestGetLeakDetectors(t *testing.T) {

--- a/internal/collector/chassis_collector_test.go
+++ b/internal/collector/chassis_collector_test.go
@@ -103,15 +103,30 @@ func TestCollectSurvivesOneUnreachableChassis(t *testing.T) {
 	require.Equal(t, "Chassis_0", health[0].labels["chassis_id"])
 }
 
+// TestGetChassisSensorsUsesExpand pins that the request actually carries $expand. The BMC
+// only inlines the member bodies when asked, so a dropped $expand costs every sensor on
+// every platform — the server here answers with link-only members when it is missing, which
+// is what a real BMC does.
 func TestGetChassisSensorsUsesExpand(t *testing.T) {
 	server := newTestRedfishServer(t)
 	server.addRouteFromFixture("/redfish/v1/Chassis", "chassis_collection.json")
 	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0", "chassis_main.json")
-	server.addRouteFromFixture("/redfish/v1/Chassis/Chassis_0/Sensors", "chassis_sensors_expanded.json")
 
-	var expandedRequests int
+	expanded := loadTestData(t, "chassis_sensors_expanded.json")
+	var expandQueries []string
+	server.mux.HandleFunc("/redfish/v1/Chassis/Chassis_0/Sensors", func(w http.ResponseWriter, r *http.Request) {
+		expandQueries = append(expandQueries, r.URL.Query().Get("$expand"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("$expand") == "" {
+			_, _ = w.Write([]byte(`{"@odata.id":"/redfish/v1/Chassis/Chassis_0/Sensors","Members":[{"@odata.id":"/redfish/v1/Chassis/Chassis_0/Sensors/Chassis_0_FAN_1_FRONT"}]}`))
+			return
+		}
+		_ = json.NewEncoder(w).Encode(expanded)
+	})
+
+	var perSensorRequests int
 	server.mux.HandleFunc("/redfish/v1/Chassis/Chassis_0/Sensors/", func(w http.ResponseWriter, r *http.Request) {
-		expandedRequests++
+		perSensorRequests++
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
@@ -128,10 +143,10 @@ func TestGetChassisSensorsUsesExpand(t *testing.T) {
 	require.NoError(t, err)
 
 	links := chassisAdvertisedLinks(chassis[0])
-	sensors, err := collector.getChassisSensors(context.Background(), links.sensorsPath(chassis[0]), NewTestLogger(t, slog.LevelDebug))
-	require.NoError(t, err)
+	sensors := collector.getChassisSensors(context.Background(), links.sensorsPath(chassis[0]), NewTestLogger(t, slog.LevelDebug))
 	require.Len(t, sensors, 6, "all sensors should arrive from the single expanded request")
-	require.Zero(t, expandedRequests, "no per-sensor requests should be issued when $expand is honoured")
+	require.Equal(t, []string{".($levels=1)"}, expandQueries, "the collection must be requested with $expand, exactly once")
+	require.Zero(t, perSensorRequests, "no per-sensor requests should be issued when $expand is honoured")
 }
 
 // TestGetChassisSensorsSkipsChassisWithoutSensors covers the ERoT/IRoT chassis that make up
@@ -222,11 +237,69 @@ func TestGetChassisSensorsBoundedWhenExpandIgnored(t *testing.T) {
 	require.NoError(t, err)
 
 	links := chassisAdvertisedLinks(chassis[0])
-	sensors, err := collector.getChassisSensors(context.Background(), links.sensorsPath(chassis[0]), NewTestLogger(t, slog.LevelDebug))
-	require.NoError(t, err)
+	sensors := collector.getChassisSensors(context.Background(), links.sensorsPath(chassis[0]), NewTestLogger(t, slog.LevelDebug))
 
 	require.Empty(t, sensors, "an unexpanded collection yields no bulk sensors")
 	require.Empty(t, perSensorRequests, "no sensor may be fetched individually")
+}
+
+// TestSensorsAreNotCollectedAlongsideThermal pins the invariant the whole fallback rests on:
+// a chassis that implements Thermal must not also be read through Sensors. Both express the
+// same temperature, so collecting both publishes redfish_chassis_temperature_celsius twice
+// under one label set, which fails the entire scrape at registration rather than merely
+// thinning it — on the legacy platforms, not the new ones this PR is for.
+func TestSensorsAreNotCollectedAlongsideThermal(t *testing.T) {
+	server := newTestRedfishServer(t)
+	server.addRoute("/redfish/v1/Chassis", map[string]any{
+		"@odata.id":   "/redfish/v1/Chassis",
+		"@odata.type": "#ChassisCollection.ChassisCollection",
+		"Members":     []map[string]string{{"@odata.id": "/redfish/v1/Chassis/Chassis_0"}},
+	})
+	// A legacy chassis: Thermal as well as a Sensors collection. Both carry the same
+	// reading, which is exactly the collision to avoid.
+	server.addRoute("/redfish/v1/Chassis/Chassis_0", map[string]any{
+		"@odata.id":   "/redfish/v1/Chassis/Chassis_0",
+		"@odata.type": "#Chassis.v1_22_0.Chassis",
+		"Id":          "Chassis_0",
+		"Status":      map[string]any{"Health": "OK", "State": "Enabled"},
+		"Thermal":     map[string]string{"@odata.id": "/redfish/v1/Chassis/Chassis_0/Thermal"},
+		"Sensors":     map[string]string{"@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors"},
+	})
+	server.addRoute("/redfish/v1/Chassis/Chassis_0/Thermal", map[string]any{
+		"@odata.id": "/redfish/v1/Chassis/Chassis_0/Thermal",
+		"Id":        "Thermal",
+		"Temperatures": []map[string]any{{
+			"MemberId":       "Chassis_0_Front_IO_Temp_0",
+			"Name":           "Chassis 0 Front IO Temp 0",
+			"ReadingCelsius": 27.5,
+			"Status":         map[string]any{"Health": "OK", "State": "Enabled"},
+		}},
+	})
+
+	var sensorRequests int
+	server.mux.HandleFunc("/redfish/v1/Chassis/Chassis_0/Sensors", func(w http.ResponseWriter, r *http.Request) {
+		sensorRequests++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(loadTestData(t, "chassis_sensors_expanded.json"))
+	})
+
+	client := connectToTestServer(t, server.Server)
+	t.Cleanup(func() {
+		client.Logout()
+		server.Close()
+	})
+
+	collector, err := NewChassisCollector(t.Name(), client, NewTestLogger(t, slog.LevelDebug), config.DefaultChassisCollector)
+	require.NoError(t, err)
+
+	ch := make(chan prometheus.Metric, 256)
+	collector.CollectWithContext(context.Background(), ch)
+	metrics := drainMetrics(t, ch)
+
+	require.Zero(t, sensorRequests, "a chassis advertising Thermal must not be asked for Sensors")
+	celsius := requireMetric(t, metrics, "redfish_chassis_temperature_celsius")
+	require.InDelta(t, 27.5, celsius.value, 1e-9, "the reading must come from Thermal, once")
+	require.NotContains(t, metrics, "redfish_chassis_sensor_reading", "no Sensors series may appear")
 }
 
 func TestChassisAdvertisedLinks(t *testing.T) {
@@ -258,6 +331,19 @@ func TestChassisAdvertisedLinks(t *testing.T) {
 		"empty link objects do not count": {
 			raw:        `{"Id":"1","Thermal":{},"Power":{},"Sensors":{}}`,
 			wantLegacy: false,
+		},
+		// A reference object may spell its URI "href", which gofish accepts. Reading only
+		// "@odata.id" would have this conclude the chassis has no Thermal while gofish
+		// collects one, and the chassis would publish its temperatures from both paths at
+		// once — a duplicate series, which fails the whole scrape at registration.
+		"href spelling counts as a link": {
+			raw:        `{"Id":"1","Thermal":{"href":"/redfish/v1/Chassis/1/Thermal"}}`,
+			wantLegacy: true,
+		},
+		"href spelling is followed for Sensors too": {
+			raw:         `{"Id":"Chassis_0","Sensors":{"href":"/redfish/v1/Chassis/Chassis_0/Sensors"}}`,
+			wantLegacy:  false,
+			wantSensors: "/redfish/v1/Chassis/Chassis_0/Sensors",
 		},
 	}
 
@@ -319,11 +405,7 @@ func TestLeakDetectorSensorIsNeverAChassisVoltage(t *testing.T) {
 	require.Contains(t, metrics, "redfish_chassis_temperature_celsius")
 	require.Contains(t, metrics, "redfish_chassis_sensor_watts")
 
-	// The detector's voltage does not, under any series name.
-	for _, sample := range metrics["redfish_chassis_power_voltage_volts"] {
-		require.NotContains(t, sample.labels["power_voltage_id"], "LeakDetector",
-			"a leak detector must not be published as a chassis power voltage")
-	}
+	// The detector's voltage does not, under any series name — power_voltage included.
 	for name, samples := range metrics {
 		for _, sample := range samples {
 			for _, label := range []string{"sensor_id", "power_voltage_id"} {
@@ -435,6 +517,93 @@ func TestParseChassisSensor(t *testing.T) {
 		require.InDelta(t, 132.0, reading.value, 1e-9)
 		require.Equal(t, "m", reading.labels["sensor_units"])
 	})
+}
+
+// TestFanPercentageSharedByBothPaths drives the same firmware numbers through the Thermal
+// and the Sensors path and requires one answer from both, series identity included. An alert
+// on redfish_chassis_fan_rpm_percentage has to mean the same thing on a platform reporting
+// fans through Sensors as on one reporting them through Thermal, which holds only for as long
+// as the two go on sharing fanPercentage and fanUnitLabel.
+//
+// The two schemas spell the units differently — Thermal's enum has "RPM" and "Percent" where
+// a Sensor has "RPM" and "%" — so each case states both spellings of one unit.
+func TestFanPercentageSharedByBothPaths(t *testing.T) {
+	tT := map[string]struct {
+		reading       float64
+		min           float64
+		max           float64
+		upperCritical float64
+		upperFatal    float64
+		thermalUnits  schemas.ReadingUnits
+		sensorUnits   string
+		want          float64
+		wantUnitLabel string
+	}{
+		"a plain reading range": {reading: 8623, min: 2000, max: 30000, want: 35.41},
+		// Some vendors (e.g. PowerEdge C6420) report no range at all but do supply the
+		// upper thresholds, which then stand in for the max.
+		"no range, upper critical only":   {reading: 50, upperCritical: 20000, want: 0.25},
+		"no range, both upper thresholds": {reading: 50, upperCritical: 20000, upperFatal: 24000, want: 0.2083333},
+		// Nothing to divide by: the percentage is zero rather than an infinity.
+		"no range and no thresholds": {reading: 8623, want: 0},
+		// A fan already reporting a duty cycle needs no derivation, and the two spellings
+		// of that unit must not split the series in two. The reading is whole because the
+		// Thermal schema carries it as an int.
+		"a reading already in percent": {
+			reading: 30, max: 30000, thermalUnits: schemas.PercentReadingUnits, sensorUnits: "%",
+			want: 30, wantUnitLabel: "percent",
+		},
+	}
+
+	for name, test := range tT {
+		t.Run(name, func(t *testing.T) {
+			intPtr := func(v float64) *int { i := int(v); return &i }
+			floatPtr := func(v float64) *float64 { return &v }
+
+			thermalUnits, sensorUnits := test.thermalUnits, test.sensorUnits
+			if thermalUnits == "" {
+				thermalUnits, sensorUnits = schemas.RPMReadingUnits, "RPM"
+			}
+			wantUnitLabel := test.wantUnitLabel
+			if wantUnitLabel == "" {
+				wantUnitLabel = "rpm"
+			}
+
+			thermalCh := make(chan prometheus.Metric, 32)
+			parseChassisFan(thermalCh, "Chassis_0", schemas.ThermalFan{
+				Entity:                 schemas.Entity{ID: "FAN_0", Name: "FAN_0"},
+				MemberID:               "FAN_0",
+				ReadingUnits:           thermalUnits,
+				Reading:                intPtr(test.reading),
+				MinReadingRange:        intPtr(test.min),
+				MaxReadingRange:        intPtr(test.max),
+				UpperThresholdCritical: intPtr(test.upperCritical),
+				UpperThresholdFatal:    intPtr(test.upperFatal),
+			})
+			thermal := requireMetric(t, drainMetrics(t, thermalCh), "redfish_chassis_fan_rpm_percentage")
+
+			sensorCh := make(chan prometheus.Metric, 32)
+			parseChassisSensor(sensorCh, "Chassis_0", &schemas.Sensor{
+				Entity:          schemas.Entity{ID: "FAN_0", Name: "FAN_0"},
+				ReadingType:     schemas.RotationalReadingType,
+				ReadingUnits:    sensorUnits,
+				Reading:         floatPtr(test.reading),
+				ReadingRangeMin: floatPtr(test.min),
+				ReadingRangeMax: floatPtr(test.max),
+				Thresholds: schemas.Thresholds{
+					UpperCritical: schemas.Threshold{Reading: floatPtr(test.upperCritical)},
+					UpperFatal:    schemas.Threshold{Reading: floatPtr(test.upperFatal)},
+				},
+			})
+			sensor := requireMetric(t, drainMetrics(t, sensorCh), "redfish_chassis_fan_rpm_percentage")
+
+			require.Equal(t, wantUnitLabel, thermal.labels["fan_unit"])
+			require.Equal(t, thermal.labels["fan_unit"], sensor.labels["fan_unit"],
+				"one fan must not land under two fan_unit spellings")
+			require.InDelta(t, test.want, thermal.value, 1e-6)
+			require.InDelta(t, thermal.value, sensor.value, 1e-9)
+		})
+	}
 }
 
 func TestGetLeakDetectors(t *testing.T) {

--- a/internal/collector/redfish_collector.go
+++ b/internal/collector/redfish_collector.go
@@ -199,6 +199,11 @@ func newRedfishClient(ctx context.Context, host string, username string, passwor
 	return redfishClient, nil
 }
 
+// odataLink is a Redfish reference object, which is absent, empty, or carries a URI.
+type odataLink struct {
+	ODataID string `json:"@odata.id"`
+}
+
 func parseCommonStatusHealth(status schemas.Health) (float64, bool) {
 	if bytes.Equal([]byte(status), []byte("OK")) {
 		return float64(1), true

--- a/internal/collector/redfish_collector.go
+++ b/internal/collector/redfish_collector.go
@@ -199,11 +199,6 @@ func newRedfishClient(ctx context.Context, host string, username string, passwor
 	return redfishClient, nil
 }
 
-// odataLink is a Redfish reference object, which is absent, empty, or carries a URI.
-type odataLink struct {
-	ODataID string `json:"@odata.id"`
-}
-
 func parseCommonStatusHealth(status schemas.Health) (float64, bool) {
 	if bytes.Equal([]byte(status), []byte("OK")) {
 		return float64(1), true

--- a/internal/collector/testdata/chassis_main.json
+++ b/internal/collector/testdata/chassis_main.json
@@ -19,6 +19,9 @@
   "ThermalSubsystem": {
     "@odata.id": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem"
   },
+  "Sensors": {
+    "@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors"
+  },
   "PowerSubsystem": {
     "@odata.id": "/redfish/v1/Chassis/Chassis_0/PowerSubsystem"
   },

--- a/internal/collector/testdata/chassis_sensors_expanded.json
+++ b/internal/collector/testdata/chassis_sensors_expanded.json
@@ -1,0 +1,119 @@
+{
+  "@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors",
+  "@odata.type": "#SensorCollection.SensorCollection",
+  "Name": "Sensor Collection",
+  "Description": "Collection of Sensor resource instances for Chassis_0",
+  "Members@odata.count": 6,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors/Chassis_0_LeakDetector_0_ColdPlate",
+      "@odata.type": "#Sensor.v1_7_0.Sensor",
+      "Id": "Chassis_0_LeakDetector_0_ColdPlate",
+      "Name": "Chassis 0 LeakDetector 0 ColdPlate",
+      "Reading": 1.724,
+      "ReadingRangeMax": 1.815,
+      "ReadingRangeMin": 0.165,
+      "ReadingType": "Voltage",
+      "ReadingUnits": "V",
+      "Thresholds": {
+        "LowerCritical": {
+          "Reading": 1.65
+        },
+        "UpperCritical": {
+          "Reading": 2.0
+        }
+      },
+      "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+      }
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors/Chassis_0_FAN_1_FRONT",
+      "@odata.type": "#Sensor.v1_7_0.Sensor",
+      "Id": "Chassis_0_FAN_1_FRONT",
+      "Name": "Chassis 0 FAN 1 FRONT",
+      "Reading": 8623.0,
+      "ReadingRangeMax": 37400.0,
+      "ReadingRangeMin": 0.0,
+      "ReadingType": "Rotational",
+      "ReadingUnits": "RPM",
+      "Thresholds": {
+        "LowerCritical": {
+          "Reading": 2204.0
+        }
+      },
+      "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+      }
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors/Chassis_0_Front_IO_Temp_0",
+      "@odata.type": "#Sensor.v1_7_0.Sensor",
+      "Id": "Chassis_0_Front_IO_Temp_0",
+      "Name": "Chassis 0 Front IO Temp 0",
+      "Reading": 27.5,
+      "ReadingRangeMax": 127.0,
+      "ReadingRangeMin": -128.0,
+      "ReadingType": "Temperature",
+      "ReadingUnits": "Cel",
+      "Thresholds": {
+        "UpperCaution": {
+          "Reading": 40.0
+        },
+        "UpperCritical": {
+          "Reading": 43.0
+        },
+        "UpperFatal": {
+          "Reading": 45.0
+        }
+      },
+      "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+      }
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors/Chassis_0_FAN_1_PWM",
+      "@odata.type": "#Sensor.v1_7_0.Sensor",
+      "Id": "Chassis_0_FAN_1_PWM",
+      "Name": "Chassis 0 FAN 1 PWM",
+      "Reading": 29.80392156862745,
+      "ReadingRangeMax": 100.0,
+      "ReadingRangeMin": 0.0,
+      "ReadingType": "Percent",
+      "ReadingUnits": "%",
+      "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+      }
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors/Chassis_0_TotalHSC_Power_0",
+      "@odata.type": "#Sensor.v1_7_0.Sensor",
+      "Id": "Chassis_0_TotalHSC_Power_0",
+      "Name": "Chassis 0 TotalHSC Power 0",
+      "Reading": 1171.349692,
+      "ReadingType": "Power",
+      "ReadingUnits": "W",
+      "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+      }
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/Chassis_0/Sensors/Chassis_0_Altitude_0",
+      "@odata.type": "#Sensor.v1_7_0.Sensor",
+      "Id": "Chassis_0_Altitude_0",
+      "Name": "Chassis 0 Altitude 0",
+      "Reading": 132.0,
+      "ReadingType": "Altitude",
+      "ReadingUnits": "m",
+      "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+      }
+    }
+  ]
+}

--- a/internal/collector/testdata_loader_test.go
+++ b/internal/collector/testdata_loader_test.go
@@ -23,3 +23,15 @@ func loadTestData(t *testing.T, filename string) map[string]interface{} {
 
 	return result
 }
+
+// loadTestDataInto decodes a JSON fixture into target, for tests that want a typed
+// gofish resource rather than a generic map and do not need an HTTP server.
+func loadTestDataInto(t *testing.T, filename string, target any) {
+	t.Helper()
+
+	path := filepath.Join("testdata", filename)
+	data, err := os.ReadFile(path) //nolint:gosec // Test fixtures are controlled by test code, not user input
+	require.NoError(t, err, "Failed to read test data file: %s", filename)
+
+	require.NoError(t, json.Unmarshal(data, target), "Failed to parse test data file: %s", filename)
+}


### PR DESCRIPTION
## Why

The GB200/GB300 NVL72 trays and the MGX NVSwitch tray implement neither the deprecated `Thermal` nor `Power` schema. The chassis collector reported nothing for them beyond status and model info. They express the same readings through the `Sensors` collection instead.

## What

Fall back to `Sensors` on a chassis advertising neither legacy schema, folding each reading into the **existing** metric family wherever the meaning is unambiguous, so a Sensors-only platform produces the same series names as a `Thermal`/`Power` one and the existing alerts keep working there:

| Redfish `ReadingType` | Metric |
| --- | --- |
| `Temperature` | `redfish_chassis_temperature_celsius` (+ `_sensor_health`, `_sensor_state`) |
| `Rotational` | `redfish_chassis_fan_rpm` (+ min/max/percentage/threshold series) |
| `Voltage` | `redfish_chassis_power_voltage_volts` (+ `_state`) |
| anything else | `redfish_chassis_sensor_{watts,amperes,joules,hertz,percent,reading}` (+ `_health`, `_state`) |

The fan percentage is derived exactly the way `parseChassisFan` derives it, quirks included:
the reading is already a percentage when that is the unit, the upper thresholds stand in for a max the firmware did not report, and the formula is `(reading + min) / max` rather than the usual `(reading - min) / (max - min)`. Reproducing it precisely is the point, so a platform moving between the two paths does not shift the series under the existing alerts.

**Readings are not inferred from sensor naming.** On an NVL72 tray, fan PWM duty cycle and CPU core utilisation are both `ReadingType: Percent` and neither carries a distinguishing `PhysicalContext`, so treating `Percent` as a fan speed would mislabel over a hundred sensors per tray. `Percent` reaches the catch-all instead.

### One small relocation

`odataLink` — the generic Redfish reference object, `{"@odata.id": "..."}` — is declared in `redfish_collector.go` alongside the other shared Redfish primitives rather than in the chassis collector. It has nothing chassis-specific about it, and later work embeds it in `memberCollection` there. Five lines, unchanged content.

### Request cost is load-bearing, not incidental

- The collection is read with **`$expand`** - one request per chassis rather than one per sensor.
- The **advertised `Sensors` link is followed rather than synthesised**. The `ERoT`/`IRoT` roots advertise none and are roughly a third of the chassis on a tray or baseboard; synthesising   `<chassis>/Sensors` would cost a 404 apiece on every scrape.
- A BMC that ignores `$expand` is **not** fanned out to one request per sensor, that would multiply load against the BMCs least able to absorb it. The bulk sensor telemetry is skipped with a warning instead.

### Leak detectors are left alone

A leak detector is dual-surfaced: a `LeakDetector` resource carries its state, and a `Sensor` of the same Id carries an analog voltage. That sensor is `ReadingType: Voltage` like any other, so without an exemption the Sensors pass would fold it into the `power_voltage` family and report a leak signal as a rail measurement. The detector Ids already enumerated from `ThermalSubsystem` are used to skip them. A follow on PR gives them their proper home (`redfish_chassis_leak_detector_volts`) and the thresholds that make them interpretable.

## Behaviour change worth knowing

A chassis that advertises no `Thermal`/`Power` now gets a `Sensors` fetch it did not get before, and starts publishing series it never published. **That is the feature**, but it does change the scrape shape of existing Sensors-only platforms.

## Do not cut a release on this PR alone

`sensor_exclude` and its default land in a follow-on PR. Until then a GB300 tray publishes its 144 per-core CPU utilisation sensors (`_CoreUtil_`) - more series than the rest of this collector produces for that tray combined.