### PR TITLE
system_collector: dedupe duplicate drive/volume listings

### DIFF
--- a/internal/collector/system_collector.go
+++ b/internal/collector/system_collector.go
@@ -161,6 +161,13 @@ func (s *SystemCollector) collect(ctx context.Context, ch chan<- prometheus.Metr
 	if systems, err := service.Systems(); err != nil {
 		logger.Error("error getting systems from service", slog.String("operation", "service.Systems()"), slog.Any("error", err))
 	} else {
+		// Some BMC firmwares list the same drive or volume more than once.
+		// Duplicate label sets fail the entire gather, turning
+		// the scrape into an HTTP 500, so emit only the first occurrence of
+		// each label set. Drive/volume labels carry no system dimension, so
+		// track across systems.
+		seenVolumes := make(map[string]struct{})
+		seenDrives := make(map[string]struct{})
 		for _, system := range systems {
 			if ctx.Err() != nil {
 				s.logger.With("error", ctx.Err(), "collector", "system").Debug("skipping further collection")
@@ -259,6 +266,12 @@ func (s *SystemCollector) collect(ctx context.Context, ch chan<- prometheus.Metr
 						systemLogger.Error("error getting storage data from system", slog.String("operation", "system.Volumes()"), slog.Any("wrror", err))
 					} else {
 						for _, volume := range volumes {
+							volumeKey := volume.Name + "\x00" + volume.ID
+							if _, dup := seenVolumes[volumeKey]; dup {
+								systemLogger.Debug("skipping duplicate volume listing", slog.String("storage", storageID), slog.String("volume", volume.ID))
+								continue
+							}
+							seenVolumes[volumeKey] = struct{}{}
 							eg.Go(func() error {
 								parseVolume(ch, volume)
 								return nil
@@ -273,6 +286,12 @@ func (s *SystemCollector) collect(ctx context.Context, ch chan<- prometheus.Metr
 						systemLogger.Info("no drive data found", slog.String("operation", "system.Drives()"), slog.String("storage", storage.ID))
 					} else {
 						for _, drive := range drives {
+							driveKey := drive.Name + "\x00" + drive.ID + "\x00" + storageID
+							if _, dup := seenDrives[driveKey]; dup {
+								systemLogger.Debug("skipping duplicate drive listing", slog.String("storage", storageID), slog.String("drive", drive.ID))
+								continue
+							}
+							seenDrives[driveKey] = struct{}{}
 							eg.Go(func() error {
 								parseDrive(ch, drive, storageID)
 								return nil

--- a/internal/collector/system_collector_test.go
+++ b/internal/collector/system_collector_test.go
@@ -321,3 +321,73 @@ func TestSystemCollectorBiosInfo(t *testing.T) {
 	require.Equal(t, "2.4b", biosInfoLabels[0]["bios_version"])
 	require.Equal(t, "SYS-A21GE-NBRT-01-LL014", biosInfoLabels[0]["model"])
 }
+
+// TestDuplicateDriveListingGathers reproduces BMC firmwares that list the
+// same drive more than once under a single storage controller. Without
+// dedupe, the duplicate label sets fail the entire registry gather ("was
+// collected before with the same name and label values"), which turns every
+// scrape of such a host into an HTTP 500.
+func TestDuplicateDriveListingGathers(t *testing.T) {
+	srv := newTestRedfishServer(t)
+
+	systemPath := "/redfish/v1/Systems/System1"
+	storagePath := systemPath + "/Storage/Storage.1"
+	drivePath := storagePath + "/Drives/Drive.Bay.1"
+
+	system := srv.loadFixture("system1.json")
+	system["Storage"] = map[string]string{"@odata.id": systemPath + "/Storage"}
+	delete(system, "Processors") // keep the mock focused on storage
+	srv.addRoute(systemPath, system)
+
+	srv.addRoute(systemPath+"/Storage", map[string]any{
+		"@odata.type": "#StorageCollection.StorageCollection",
+		"Members": []map[string]string{
+			{"@odata.id": storagePath},
+		},
+	})
+
+	// The BMC references the same drive twice within one storage subsystem.
+	srv.addRoute(storagePath, map[string]any{
+		"@odata.type": "#Storage.v1_13_0.Storage",
+		"@odata.id":   storagePath,
+		"Id":          "Storage.1",
+		"Name":        "Storage.1",
+		"Drives": []map[string]string{
+			{"@odata.id": drivePath},
+			{"@odata.id": drivePath},
+		},
+	})
+
+	srv.addRoute(drivePath, map[string]any{
+		"@odata.type":   "#Drive.v1_16_0.Drive",
+		"@odata.id":     drivePath,
+		"Id":            "Drive.Bay.1",
+		"Name":          "Drive.Bay.1",
+		"CapacityBytes": 1920398934016,
+		"Status":        map[string]string{"State": "Enabled", "Health": "OK"},
+	})
+
+	client := connectToTestServer(t, srv.Server)
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	collector, err := NewSystemCollector(t.Name(), client, logger, config.DefaultSystemCollector)
+	require.NoError(t, err)
+
+	registry := prometheus.NewPedanticRegistry()
+	require.NoError(t, registry.Register(collector))
+
+	families, err := registry.Gather()
+	require.NoError(t, err, "gather must not fail on duplicate drive listings")
+
+	got := map[string]int{}
+	for _, mf := range families {
+		if strings.HasPrefix(mf.GetName(), "redfish_system_storage_drive_") {
+			got[mf.GetName()] = len(mf.GetMetric())
+		}
+	}
+	assert.Equal(t, map[string]int{
+		"redfish_system_storage_drive_state":        1,
+		"redfish_system_storage_drive_health_state": 1,
+		"redfish_system_storage_drive_capacity":     1,
+	}, got, "each drive metric family should carry exactly one deduped series")
+}


### PR DESCRIPTION
## Why

Some BMC firmwares list the same physical drive more than once under a single storage controller. The system collector emits every occurrence, and duplicate label sets make the Prometheus registry reject the entire gather:

```
collected metric "redfish_system_storage_drive_state" {...} was collected before with the same name and label values
```

The exporter then serves HTTP 500 for the whole scrape, so one quirky storage enumeration takes down every metric family for that target — not just storage.

## What

- Emit only the first occurrence of each drive/volume label set in the system collector's storage loop; skips log at debug.
- The dedupe key is the exact label set (name + id + storage controller ID for drives), so the same drive legitimately reported under *different* controllers still emits distinct series (existing `TestDriveMetrics` coverage is unaffected).
- Tracked across systems, since the label set carries no system dimension.

## Testing

- New `TestDuplicateDriveListingGathers` runs the collector against a mock BMC that double-lists a drive and gathers through `prometheus.NewPedanticRegistry`; without the fix it fails with the duplicate-metric error above.
- `go vet ./...` and the full `go test ./...` suite pass.

## Live demonstration (in production in the environment where this was originally failing)

See [Slack](https://lambda.slack.com/archives/C06HNA3572R/p1787868456412179?thread_ts=1787789107.066269&cid=C06HNA3572R).

🤖 Generated with [Claude Code](https://claude.com/claude-code)