### PR TITLE
fix for bug that left sessions open

### DIFF
--- a/cmd/redfish-exporter/main.go
+++ b/cmd/redfish-exporter/main.go
@@ -103,6 +103,7 @@ func registerMetaMetrics() {
 		collectorModuleUnknown,
 		scrapeSuccessesTotal,
 	}
+	custom = append(custom, collector.SessionMetrics()...)
 
 	prometheus.DefaultRegisterer.MustRegister(custom...)
 }
@@ -213,6 +214,12 @@ func metricsHandler() http.HandlerFunc {
 			http.Error(w, fmt.Sprintf("unable to construct aggregate collector: %s", err), statusCode)
 			return
 		}
+		// NewRedfishCollector has opened a session on the BMC. Release it on every exit path
+		// from here on, including the one where the scrape context is already cancelled and
+		// Collect() declines to do any work: BMCs cap concurrent sessions and refuse all new
+		// ones once full, so an abandoned session denies service to subsequent scrapes until
+		// the BMC's own idle timeout reclaims the slot.
+		defer aggregateCollector.Close()
 
 		collectors := buildCollectorsFor(r.Context(), sr.Modules, safeConfig.GetModules(), aggregateCollector.Client(), scrapeLogger)
 		aggregateCollector.WithCollectors(collectors)

--- a/config.example.yml
+++ b/config.example.yml
@@ -12,6 +12,32 @@ groups:
 # loglevel can be one of "debug", "info", "warn", "error"
 loglevel: info
 
+# Tuning for the Redfish (gofish) client. Every value shown is the default.
+redfish_client:
+  # Maximum concurrent HTTP requests per scrape, per target.
+  max_concurrent_requests: 1
+  # Bounds TCP connect and TLS handshake.
+  dial_timeout: 10s
+  # Bounds the wait for response headers after a request is written. Raise this only if a
+  # BMC is legitimately slow to answer; the point of the bound is that a BMC which
+  # completes TCP and TLS and then goes silent must not park a request indefinitely.
+  response_header_timeout: 30s
+  # Bounds the session DELETE issued at the end of each scrape. This request runs on a
+  # context detached from the scrape's, because the scrape context is often already
+  # cancelled by then, so it needs a deadline of its own.
+  logout_timeout: 10s
+  # Authenticate each request with HTTP basic auth instead of creating a Redfish session.
+  #
+  # BMCs cap concurrent sessions — commonly around ten — and once the table is full they
+  # refuse every new session, which presents as HTTP 503 or Base.1.x.SessionLimitExceeded
+  # on a device that is otherwise perfectly reachable. Session auth costs one slot per
+  # scrape and any scrape whose session is not released leaves that slot occupied until
+  # the BMC's own idle timeout reclaims it. Basic auth opens no session at all, so the
+  # exporter stops competing for slots entirely, at the cost of re-authenticating per
+  # request. Enable it for targets that share a BMC with other Redfish clients, or that
+  # are already at their session cap. Requires the BMC to accept basic auth on Redfish.
+  basic_auth: false
+
 # The modules map defines various collectors the exporter may use, at client discretion.
 # Clients like Prometheus should specify one or more 'modules' HTTP query parameters
 # for each scrape, mapping to one or more of the defined modules below.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -13,6 +13,7 @@ hosts:
 groups:
   [ <string>: <hostdetail> ]
 modules: [ <string>: <module> ]
+[ redfish_client: <redfish_client> ]
 ```
 
 ## `<hostdetail>`
@@ -22,6 +23,35 @@ password: <string>
 ```
 
 Note that the `default` entry above is useful in order to avoid the exporter failing when attempting to collect from a host not explicitly defined in `hosts`.
+
+## `<redfish_client>`
+
+Tuning for the underlying Redfish (gofish) client. Every value below is optional and shown with its default.
+
+```yaml
+[ max_concurrent_requests: <int> | default = 1 ]
+[ dial_timeout: <timeout> | default = 10s ]
+[ response_header_timeout: <timeout> | default = 30s ]
+[ logout_timeout: <timeout> | default = 10s ]
+[ basic_auth: <bool> | default = false ]
+```
+
+Each key may also be set from the environment as `REDFISH_CLIENT_<KEY>` (prefixed further if `--config.env-prefix` is given), e.g. `REDFISH_CLIENT_BASIC_AUTH=true`.
+
+### Session limits and `basic_auth`
+
+BMCs cap the number of concurrent Redfish sessions — commonly around ten — and once that table is full they refuse every new session. On a device in that state the exporter sees an immediate `HTTP 503` or an explicit `Base.1.x.SessionLimitExceeded`, and other Redfish clients on the same device see their own failures, typically a connect that completes TCP and TLS and then never gets an answer. Nothing is wrong with the network or the BMC; the device is simply out of slots.
+
+By default the exporter authenticates by creating a session, which costs one slot per scrape and returns it at the end of the scrape. That is fine on its own, but two things make slots scarce in practice:
+
+- **Churn.** Every scrape of every module is a separate session create and delete. Several modules scraped on a short interval, plus any other Redfish client polling the same BMC, can mean a double-digit number of create/delete cycles per BMC per interval against a cap of ten.
+- **Leaks.** A slot released late or not at all stays occupied until the BMC's own idle timeout reclaims it. Because the churn never stops, leaking even a small fraction fills the table within one idle-timeout period, after which the device refuses everything and never drains.
+
+Setting `basic_auth: true` authenticates each request with HTTP basic auth and creates no session at all, which removes the exporter from the competition for slots entirely. The trade-off is per-request re-authentication, and the requirement that the BMC accept basic auth on its Redfish endpoint. It is the right setting for targets that share a BMC with other Redfish clients, and the fastest remedy for targets already pinned at their cap.
+
+The two timeouts exist for the same failure. `response_header_timeout` bounds the wait for response headers once a request is written, so a BMC that completes TCP and TLS and then goes silent cannot park a request indefinitely. `logout_timeout` bounds the session delete at the end of a scrape specifically: that request deliberately runs on a context detached from the scrape's — the scrape context is frequently already cancelled by the time teardown is reached, and a cancelled context cannot carry the request that cleans up after it — so it needs a deadline of its own.
+
+To see whether a device is leaking, use `redfish_exporter_sessions_abandoned_total` and `redfish_exporter_session_logouts_total`. Both are labelled by `target`, i.e. the BMC address, so a leak is attributable to a device rather than to an exporter instance.
 
 ## `<module>`
 Users of `blackbox_exporter` will be familiar with the concept of [modules (aka probers)](https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md#module).

--- a/internal/collector/redfish_collector.go
+++ b/internal/collector/redfish_collector.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -43,6 +44,26 @@ var (
 	)
 )
 
+// Session-lifecycle metrics. These are labelled by the BMC address rather than by the
+// exporter instance, because the quantity that matters is per-device: a BMC caps concurrent
+// sessions and refuses all new ones once full, so leaks have to be attributable to a device.
+var (
+	sessionLogoutsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: prometheus.BuildFQName(namespace, exporter, "session_logouts_total"),
+		Help: "Redfish session teardown attempts by target and outcome (success, failure, skipped).",
+	}, []string{"target", "result"})
+
+	sessionsAbandonedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: prometheus.BuildFQName(namespace, exporter, "sessions_abandoned_total"),
+		Help: "Redfish sessions this exporter opened but could not delete, by target. Each one occupies a session slot on the BMC until the BMC's own idle timeout reclaims it.",
+	}, []string{"target"})
+)
+
+// SessionMetrics returns the session-lifecycle metrics so the caller can register them.
+func SessionMetrics() []prometheus.Collector {
+	return []prometheus.Collector{sessionLogoutsTotal, sessionsAbandonedTotal}
+}
+
 // redfishCollector is an aggregation of various other prometheus.Collector.
 // It implements prometheus.Collector, and at Describe or Collect time will iterate all of
 // its own collectors to yield data.
@@ -52,6 +73,12 @@ type redfishCollector struct {
 	redfishClient *gofish.APIClient
 	collectors    []ContextAwareCollector
 	redfishUp     prometheus.Gauge
+
+	// host and logoutTimeout are retained for Close(), which has to be able to tear the
+	// session down after the scrape context is gone.
+	host          string
+	logoutTimeout time.Duration
+	closeOnce     sync.Once
 
 	// collectorsSucceeded and collectorsFailed track how many sub-collectors
 	// completed successfully or failed in the most recent Collect() call.
@@ -70,10 +97,17 @@ func NewRedfishCollector(ctx context.Context, logger *slog.Logger, host string, 
 		return nil, err
 	}
 
+	logoutTimeout := rfConfig.LogoutTimeout
+	if logoutTimeout <= 0 {
+		logoutTimeout = config.DefaultRedfishConfig.LogoutTimeout
+	}
+
 	return &redfishCollector{
 		ctx:           ctx,
 		logger:        logger,
 		redfishClient: redfishClient,
+		host:          host,
+		logoutTimeout: logoutTimeout,
 		redfishUp: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
@@ -100,6 +134,52 @@ func (r *redfishCollector) Client() *gofish.APIClient {
 	return r.redfishClient
 }
 
+// Close releases the Redfish session that NewRedfishCollector opened. It is idempotent and
+// safe to call on a collector whose Collect() never ran.
+//
+// The session has to be released on every exit path, not only the one where collection
+// actually happened. BMCs cap concurrent sessions — commonly around ten — and once the table
+// is full they refuse every new session, so a session abandoned by an aborted scrape denies
+// service to the next scrape until the BMC's own idle timeout reclaims the slot. Callers
+// should defer Close() as soon as the collector is constructed.
+//
+// The delete deliberately runs on a context detached from the scrape's. By the time Close()
+// is reached the scrape context is frequently already cancelled — that is precisely the case
+// that leaks — and a cancelled context cannot carry the request that would clean up after it.
+// The detached context gets its own timeout so a BMC that completes TCP and TLS and then goes
+// silent cannot park this goroutine, and the request itself, indefinitely.
+func (r *redfishCollector) Close() {
+	r.closeOnce.Do(func() {
+		if r.redfishClient == nil {
+			return
+		}
+		session, err := r.redfishClient.GetSession()
+		if err != nil {
+			// No session to release: basic auth, or a session already deleted.
+			sessionLogoutsTotal.WithLabelValues(r.host, "skipped").Inc()
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(r.ctx), r.logoutTimeout)
+		defer cancel()
+
+		client := r.redfishClient.WithContext(ctx)
+		defer client.HTTPClient.CloseIdleConnections()
+
+		// DeleteSession is called directly rather than through gofish's Logout(), which
+		// discards the error and would leave a failed teardown invisible.
+		if err := client.Service.DeleteSession(session.ID); err != nil {
+			sessionLogoutsTotal.WithLabelValues(r.host, "failure").Inc()
+			sessionsAbandonedTotal.WithLabelValues(r.host).Inc()
+			r.logger.Error("failed to delete redfish session; the session slot stays occupied on the BMC until its own timeout reclaims it",
+				slog.String("session", session.ID),
+				slog.Any("error", err))
+			return
+		}
+		sessionLogoutsTotal.WithLabelValues(r.host, "success").Inc()
+	})
+}
+
 // Describe implements prometheus.Collector.
 func (r *redfishCollector) Describe(ch chan<- *prometheus.Desc) {
 	for _, collector := range r.collectors {
@@ -120,7 +200,8 @@ func (r *redfishCollector) Collect(ch chan<- prometheus.Metric) {
 		r.redfishUp.Set(0)
 	} else {
 		r.redfishUp.Set(1)
-		defer r.redfishClient.Logout()
+		// Session teardown is the caller's responsibility via Close(), so that it also
+		// happens on the branch above and on any path where Collect() is never reached.
 		eg := newRecoverGroup(r.ctx)
 		for _, collector := range r.collectors {
 			eg.Go(func() error {
@@ -165,16 +246,26 @@ func newRedfishClient(ctx context.Context, host string, username string, passwor
 		KeepAlive: 30 * time.Second,
 	}
 
+	responseHeaderTimeout := rfConfig.ResponseHeaderTimeout
+	if responseHeaderTimeout <= 0 {
+		responseHeaderTimeout = config.DefaultRedfishConfig.ResponseHeaderTimeout
+	}
+
 	transport := &http.Transport{
 		DialContext:         dialer.DialContext,
 		TLSHandshakeTimeout: rfConfig.DialTimeout,
+		// A silent-but-reachable BMC is the common failure here: TCP and TLS complete and
+		// the response headers never arrive. Requests carrying a scrape context are bounded
+		// by that context, but the session teardown intentionally runs on a detached one, so
+		// the transport needs a bound of its own.
+		ResponseHeaderTimeout: responseHeaderTimeout,
 	}
 
 	client := &http.Client{
 		Transport: transport,
 	}
 
-	config := gofish.ClientConfig{
+	clientConfig := gofish.ClientConfig{
 		HTTPClient:            client,
 		MaxConcurrentRequests: rfConfig.MaxConcurrentRequests,
 		Endpoint:              url,
@@ -182,8 +273,11 @@ func newRedfishClient(ctx context.Context, host string, username string, passwor
 		Password:              password,
 		Insecure:              true,
 		ReuseConnections:      true, // Enable HTTP keepalive for connection reuse
+		// With BasicAuth the client authenticates per request and never creates a Redfish
+		// session, so the exporter stops consuming the BMC's limited session slots at all.
+		BasicAuth: rfConfig.BasicAuth,
 	}
-	redfishClient, err := gofish.ConnectContext(ctx, config)
+	redfishClient, err := gofish.ConnectContext(ctx, clientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/collector/session_test.go
+++ b/internal/collector/session_test.go
@@ -1,0 +1,400 @@
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LambdaLabs/redfish_exporter/internal/config"
+)
+
+// fakeBMC is a Redfish service root that implements the session service and, crucially,
+// keeps a count of how many sessions are currently open. The BMCs this exporter talks to
+// cap concurrent sessions and refuse every new session once the table is full, so the
+// assertion that matters for session-lifecycle tests is "did the slot come back".
+type fakeBMC struct {
+	*httptest.Server
+
+	mu       sync.Mutex
+	open     map[string]bool
+	created  int
+	deleted  int
+	deleteOK bool
+
+	// blockDeletes, when non-nil, holds every DELETE until the channel is closed. It
+	// reproduces a BMC that completes TCP and TLS and then declines to answer.
+	blockDeletes chan struct{}
+}
+
+func newFakeBMC(t *testing.T) *fakeBMC {
+	t.Helper()
+
+	b := &fakeBMC{
+		open:     make(map[string]bool),
+		deleteOK: true,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"@odata.id":      "/redfish/v1/",
+			"@odata.type":    "#ServiceRoot.v1_15_0.ServiceRoot",
+			"Id":             "RootService",
+			"Name":           "Root Service",
+			"RedfishVersion": "1.15.0",
+			"Links": map[string]any{
+				"Sessions": map[string]any{"@odata.id": "/redfish/v1/SessionService/Sessions"},
+			},
+		}))
+	})
+
+	mux.HandleFunc("/redfish/v1/SessionService/Sessions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		b.mu.Lock()
+		b.created++
+		id := fmt.Sprintf("%d", b.created)
+		sessionURI := "/redfish/v1/SessionService/Sessions/" + id
+		b.open[sessionURI] = true
+		b.mu.Unlock()
+
+		w.Header().Set("Location", sessionURI)
+		w.Header().Set("X-Auth-Token", "token-"+id)
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mux.HandleFunc("/redfish/v1/SessionService/Sessions/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if blk := b.blocker(); blk != nil {
+			<-blk
+		}
+		b.mu.Lock()
+		b.deleted++
+		ok := b.deleteOK
+		if ok {
+			delete(b.open, r.URL.Path)
+		}
+		b.mu.Unlock()
+
+		if !ok {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// TLS, so tests drive the real newRedfishClient path (which builds an https:// endpoint
+	// and relies on the client's Insecure setting for the BMCs' self-signed certs).
+	b.Server = httptest.NewTLSServer(mux)
+	t.Cleanup(b.Close)
+	return b
+}
+
+func (b *fakeBMC) blocker() chan struct{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.blockDeletes
+}
+
+// host returns the "host:port" form the exporter's config uses as a target.
+func (b *fakeBMC) host(t *testing.T) string {
+	t.Helper()
+	u, err := url.Parse(b.URL)
+	require.NoError(t, err)
+	return u.Host
+}
+
+func (b *fakeBMC) counts() (openSessions, created, deleted int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.open), b.created, b.deleted
+}
+
+// newBMCCollector builds a redfishCollector against a fakeBMC using the exporter's own
+// client constructor, so the transport settings and auth mode under test are the real ones.
+func newBMCCollector(t *testing.T, ctx context.Context, b *fakeBMC, rfConfig config.RedfishClientConfig) *redfishCollector {
+	t.Helper()
+
+	host := b.host(t)
+	client, err := newRedfishClient(ctx, host, "user", "pass", rfConfig)
+	require.NoError(t, err)
+
+	logoutTimeout := rfConfig.LogoutTimeout
+	if logoutTimeout <= 0 {
+		logoutTimeout = config.DefaultRedfishConfig.LogoutTimeout
+	}
+
+	return &redfishCollector{
+		ctx:           ctx,
+		logger:        NewTestLogger(t, 0),
+		redfishClient: client,
+		host:          host,
+		logoutTimeout: logoutTimeout,
+		redfishUp:     prometheus.NewGauge(prometheus.GaugeOpts{Name: "redfish_up_test"}),
+	}
+}
+
+func testRedfishConfig() config.RedfishClientConfig {
+	return config.RedfishClientConfig{
+		MaxConcurrentRequests: 1,
+		DialTimeout:           2 * time.Second,
+		ResponseHeaderTimeout: 2 * time.Second,
+		LogoutTimeout:         2 * time.Second,
+	}
+}
+
+// TestClose_ReleasesSessionWhenScrapeContextCancelled covers the leak this work targets.
+// The session is opened against the inbound HTTP request's context, so when Prometheus
+// gives up on a slow scrape that context is cancelled before collection starts. Collect()
+// then declines to do any work, and before Close() existed nothing deleted the session:
+// the slot stayed occupied on the BMC until its own idle timeout reclaimed it.
+func TestClose_ReleasesSessionWhenScrapeContextCancelled(t *testing.T) {
+	bmc := newFakeBMC(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	rc := newBMCCollector(t, ctx, bmc, testRedfishConfig())
+
+	openSessions, created, _ := bmc.counts()
+	require.Equal(t, 1, created, "constructing the collector should open exactly one session")
+	require.Equal(t, 1, openSessions)
+
+	// The scrape context dies before collection begins.
+	cancel()
+
+	ch := make(chan prometheus.Metric, 32)
+	rc.Collect(ch)
+
+	// Collect() took the early-return branch, so it did not release anything.
+	openSessions, _, deleted := bmc.counts()
+	require.Equal(t, 0, deleted, "Collect() no longer owns session teardown")
+	require.Equal(t, 1, openSessions)
+
+	rc.Close()
+
+	openSessions, created, deleted = bmc.counts()
+	assert.Equal(t, 0, openSessions, "the session slot must be returned to the BMC")
+	assert.Equal(t, 1, created)
+	assert.Equal(t, 1, deleted)
+}
+
+// TestClose_ReleasesSessionAfterSuccessfulCollect verifies the ordinary path still tears the
+// session down now that teardown moved out of Collect() and into Close().
+func TestClose_ReleasesSessionAfterSuccessfulCollect(t *testing.T) {
+	bmc := newFakeBMC(t)
+	rc := newBMCCollector(t, context.Background(), bmc, testRedfishConfig())
+	rc.collectors = []ContextAwareCollector{&stubCollector{}}
+
+	ch := make(chan prometheus.Metric, 32)
+	rc.Collect(ch)
+	rc.Close()
+
+	openSessions, created, deleted := bmc.counts()
+	assert.Equal(t, 0, openSessions)
+	assert.Equal(t, 1, created)
+	assert.Equal(t, 1, deleted)
+}
+
+// TestClose_Idempotent matters because Close() is deferred by the handler while the
+// collector may be closed elsewhere; a second DELETE against a released session would
+// either error noisily or, on some BMCs, delete a slot that has since been reissued.
+func TestClose_Idempotent(t *testing.T) {
+	bmc := newFakeBMC(t)
+	rc := newBMCCollector(t, context.Background(), bmc, testRedfishConfig())
+
+	rc.Close()
+	rc.Close()
+	rc.Close()
+
+	openSessions, _, deleted := bmc.counts()
+	assert.Equal(t, 0, openSessions)
+	assert.Equal(t, 1, deleted, "only the first Close() should issue a DELETE")
+}
+
+// TestClose_NoClient guards the path where the collector never got a working client, so
+// that a deferred Close() cannot turn a failed scrape into a panic.
+func TestClose_NoClient(t *testing.T) {
+	rc := newTestRedfishCollector(nil)
+	rc.host = "no-client.invalid"
+	rc.logoutTimeout = time.Second
+
+	assert.NotPanics(t, rc.Close)
+}
+
+// TestClose_SkipsWhenNoSessionExists covers basic-auth clients, which authenticate per
+// request and never hold a session. There is nothing to delete and Close() must not
+// attempt a DELETE against an empty session URL.
+func TestClose_SkipsWhenNoSessionExists(t *testing.T) {
+	bmc := newFakeBMC(t)
+	rfConfig := testRedfishConfig()
+	rfConfig.BasicAuth = true
+
+	rc := newBMCCollector(t, context.Background(), bmc, rfConfig)
+
+	openSessions, created, _ := bmc.counts()
+	require.Equal(t, 0, created, "basic auth must not create a session")
+	require.Equal(t, 0, openSessions)
+
+	rc.Close()
+
+	_, _, deleted := bmc.counts()
+	assert.Equal(t, 0, deleted, "there is no session to delete")
+}
+
+// TestBasicAuth_ConsumesNoSessionSlots is the direct statement of why basic auth is worth
+// having: a BMC pinned at its session cap refuses new sessions, and a client that never
+// opens one is immune to that. Several scrapes in a row must leave the session table empty.
+func TestBasicAuth_ConsumesNoSessionSlots(t *testing.T) {
+	bmc := newFakeBMC(t)
+	rfConfig := testRedfishConfig()
+	rfConfig.BasicAuth = true
+
+	for range 5 {
+		rc := newBMCCollector(t, context.Background(), bmc, rfConfig)
+		ch := make(chan prometheus.Metric, 32)
+		rc.Collect(ch)
+		rc.Close()
+	}
+
+	openSessions, created, deleted := bmc.counts()
+	assert.Equal(t, 0, created, "no sessions should ever be created under basic auth")
+	assert.Equal(t, 0, openSessions)
+	assert.Equal(t, 0, deleted)
+}
+
+// TestSessionAuth_ConsumesOneSlotPerScrape documents the churn that basic auth removes:
+// with session auth every scrape opens and closes a slot, and each of those is a chance to
+// leak if the teardown is skipped or fails.
+func TestSessionAuth_ConsumesOneSlotPerScrape(t *testing.T) {
+	bmc := newFakeBMC(t)
+
+	for range 5 {
+		rc := newBMCCollector(t, context.Background(), bmc, testRedfishConfig())
+		ch := make(chan prometheus.Metric, 32)
+		rc.Collect(ch)
+		rc.Close()
+	}
+
+	openSessions, created, deleted := bmc.counts()
+	assert.Equal(t, 5, created)
+	assert.Equal(t, 5, deleted)
+	assert.Equal(t, 0, openSessions, "every slot should come back")
+}
+
+// TestClose_BoundedBySilentBMC is the second half of the leak. Once the teardown runs on a
+// context detached from the cancelled scrape context, nothing else bounds it: the HTTP
+// client has no overall timeout, so a BMC that accepts the DELETE and never answers would
+// park the handler goroutine indefinitely — one stuck goroutine and one held session per
+// scrape, growing without limit. Close() must return on its own timeout instead.
+func TestClose_BoundedBySilentBMC(t *testing.T) {
+	bmc := newFakeBMC(t)
+	block := make(chan struct{})
+	bmc.mu.Lock()
+	bmc.blockDeletes = block
+	bmc.mu.Unlock()
+	// Release the parked handler so the test server can shut down.
+	t.Cleanup(func() { close(block) })
+
+	rfConfig := testRedfishConfig()
+	rfConfig.LogoutTimeout = 250 * time.Millisecond
+
+	rc := newBMCCollector(t, context.Background(), bmc, rfConfig)
+
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		rc.Close()
+		done <- time.Since(start)
+	}()
+
+	select {
+	case elapsed := <-done:
+		assert.Less(t, elapsed, 5*time.Second, "Close() must be bounded by logoutTimeout")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close() blocked indefinitely on a silent BMC")
+	}
+}
+
+// TestClose_RecordsAbandonedSession verifies a failed teardown is counted against the BMC
+// address. The pre-existing HTTP-level DELETE metric labels the exporter instance, so it
+// cannot answer "which device is leaking", which is the only form of the question that
+// helps when a device refuses all new sessions.
+func TestClose_RecordsAbandonedSession(t *testing.T) {
+	bmc := newFakeBMC(t)
+	bmc.mu.Lock()
+	bmc.deleteOK = false
+	bmc.mu.Unlock()
+
+	rc := newBMCCollector(t, context.Background(), bmc, testRedfishConfig())
+	target := bmc.host(t)
+
+	before := testutil.ToFloat64(sessionsAbandonedTotal.WithLabelValues(target))
+	rc.Close()
+	after := testutil.ToFloat64(sessionsAbandonedTotal.WithLabelValues(target))
+
+	assert.Equal(t, float64(1), after-before, "a failed teardown must be attributed to the target")
+
+	openSessions, _, deleted := bmc.counts()
+	assert.Equal(t, 1, deleted, "the DELETE was attempted")
+	assert.Equal(t, 1, openSessions, "and the BMC kept the slot")
+}
+
+// TestClose_RecordsSuccessfulLogout checks the success counter, since an abandoned-session
+// rate is only interpretable next to the total.
+func TestClose_RecordsSuccessfulLogout(t *testing.T) {
+	bmc := newFakeBMC(t)
+	rc := newBMCCollector(t, context.Background(), bmc, testRedfishConfig())
+	target := bmc.host(t)
+
+	before := testutil.ToFloat64(sessionLogoutsTotal.WithLabelValues(target, "success"))
+	rc.Close()
+	after := testutil.ToFloat64(sessionLogoutsTotal.WithLabelValues(target, "success"))
+
+	assert.Equal(t, float64(1), after-before)
+}
+
+// TestSessionMetrics_Registerable guards against a duplicate or malformed metric definition
+// reaching main(), where registration is fatal.
+func TestSessionMetrics_Registerable(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	assert.NotEmpty(t, SessionMetrics())
+	assert.NoError(t, reg.Register(prometheus.NewGauge(prometheus.GaugeOpts{Name: "placeholder"})))
+	for _, c := range SessionMetrics() {
+		assert.NoError(t, reg.Register(c))
+	}
+}
+
+// TestRedfishClientDefaults_BoundUnsetTimeouts confirms a config that predates the new
+// timeout fields still gets bounded behaviour rather than an unlimited wait.
+func TestRedfishClientDefaults_BoundUnsetTimeouts(t *testing.T) {
+	assert.Positive(t, config.DefaultRedfishConfig.ResponseHeaderTimeout)
+	assert.Positive(t, config.DefaultRedfishConfig.LogoutTimeout)
+
+	bmc := newFakeBMC(t)
+	// Zero timeouts, as an older config file would produce.
+	rc := newBMCCollector(t, context.Background(), bmc, config.RedfishClientConfig{
+		MaxConcurrentRequests: 1,
+		DialTimeout:           2 * time.Second,
+	})
+	assert.Equal(t, config.DefaultRedfishConfig.LogoutTimeout, rc.logoutTimeout)
+
+	rc.Close()
+	openSessions, _, _ := bmc.counts()
+	assert.Equal(t, 0, openSessions)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,9 @@ var (
 	DefaultRedfishConfig = RedfishClientConfig{
 		MaxConcurrentRequests: 1,
 		DialTimeout:           10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		LogoutTimeout:         10 * time.Second,
+		BasicAuth:             false,
 	}
 )
 
@@ -76,6 +79,9 @@ func newViperInstance(envPrefix string) *viper.Viper {
 	v.SetDefault("shutdown_timeout", 60*time.Second)
 	v.SetDefault("redfish_client.max_concurrent_requests", DefaultRedfishConfig.MaxConcurrentRequests)
 	v.SetDefault("redfish_client.dial_timeout", DefaultRedfishConfig.DialTimeout)
+	v.SetDefault("redfish_client.response_header_timeout", DefaultRedfishConfig.ResponseHeaderTimeout)
+	v.SetDefault("redfish_client.logout_timeout", DefaultRedfishConfig.LogoutTimeout)
+	v.SetDefault("redfish_client.basic_auth", DefaultRedfishConfig.BasicAuth)
 
 	return v
 }
@@ -151,6 +157,19 @@ type RedfishClientConfig struct {
 	// MaxConcurrentRequests sets the gofish client maximum permitted concurrent requests.
 	MaxConcurrentRequests int64         `mapstructure:"max_concurrent_requests"`
 	DialTimeout           time.Duration `mapstructure:"dial_timeout"`
+	// ResponseHeaderTimeout bounds how long a request waits for the BMC's response headers
+	// after the request has been written. Without it, a BMC that completes TCP and TLS and
+	// then declines to answer parks the requesting goroutine for as long as it stays silent,
+	// which for a session teardown means holding a session slot open indefinitely.
+	ResponseHeaderTimeout time.Duration `mapstructure:"response_header_timeout"`
+	// LogoutTimeout bounds the session-delete request issued at the end of a scrape. It is
+	// separate from the scrape context, which is typically already cancelled by then.
+	LogoutTimeout time.Duration `mapstructure:"logout_timeout"`
+	// BasicAuth makes the client authenticate each request with HTTP basic auth instead of
+	// creating a Redfish session. BMCs cap concurrent sessions — commonly around ten — and
+	// refuse every new session once full, so basic auth removes this exporter from the
+	// competition for slots entirely at the cost of re-authenticating per request.
+	BasicAuth bool `mapstructure:"basic_auth"`
 }
 
 // Config represents the redfish_exporter config file

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,6 +39,15 @@ func TestConfigFromFile(t *testing.T) {
 	assert.Equal(t, "gpu_collector", config.Modules["foo"].Prober)
 }
 
+// redfishConfigWith returns DefaultRedfishConfig with the given overrides applied. Cases
+// below assert on the field under test rather than restating every default, so adding a
+// field with a new default does not invalidate unrelated cases.
+func redfishConfigWith(overrides func(*RedfishClientConfig)) RedfishClientConfig {
+	c := DefaultRedfishConfig
+	overrides(&c)
+	return c
+}
+
 func TestRedfishClientConfig(t *testing.T) {
 	tT := map[string]struct {
 		inputYAML     string
@@ -66,10 +75,9 @@ redfish_client:
 			wantErrString: "",
 			wantConfig: &Config{
 				ShutdownTimeout: 60 * time.Second,
-				RedfishClient: RedfishClientConfig{
-					MaxConcurrentRequests: 100,
-					DialTimeout:           10 * time.Second,
-				},
+				RedfishClient: redfishConfigWith(func(c *RedfishClientConfig) {
+					c.MaxConcurrentRequests = 100
+				}),
 			},
 		},
 		"happy path, all values changed": {
@@ -77,6 +85,9 @@ redfish_client:
 redfish_client:
   max_concurrent_requests: 100
   dial_timeout: 30s
+  response_header_timeout: 45s
+  logout_timeout: 5s
+  basic_auth: true
 `,
 			wantErrString: "",
 			wantConfig: &Config{
@@ -84,7 +95,19 @@ redfish_client:
 				RedfishClient: RedfishClientConfig{
 					MaxConcurrentRequests: 100,
 					DialTimeout:           30 * time.Second,
+					ResponseHeaderTimeout: 45 * time.Second,
+					LogoutTimeout:         5 * time.Second,
+					BasicAuth:             true,
 				},
+			},
+		},
+		"basic_auth defaults to false so session auth stays the default behaviour": {
+			inputYAML:     `loglevel: info`,
+			wantErrString: "",
+			wantConfig: &Config{
+				Loglevel:        "info",
+				ShutdownTimeout: 60 * time.Second,
+				RedfishClient:   DefaultRedfishConfig,
 			},
 		},
 		"LOGLEVEL overrides loglevel": {
@@ -102,10 +125,9 @@ redfish_client:
 			wantConfig: &Config{
 				Loglevel:        "info",
 				ShutdownTimeout: 60 * time.Second,
-				RedfishClient: RedfishClientConfig{
-					MaxConcurrentRequests: 5,
-					DialTimeout:           10 * time.Second,
-				},
+				RedfishClient: redfishConfigWith(func(c *RedfishClientConfig) {
+					c.MaxConcurrentRequests = 5
+				}),
 			},
 		},
 		"REDFISH_CLIENT_DIAL_TIMEOUT overrides redfish_client.dial_timeout": {
@@ -114,10 +136,42 @@ redfish_client:
 			wantConfig: &Config{
 				Loglevel:        "info",
 				ShutdownTimeout: 60 * time.Second,
-				RedfishClient: RedfishClientConfig{
-					MaxConcurrentRequests: 1,
-					DialTimeout:           30 * time.Second,
-				},
+				RedfishClient: redfishConfigWith(func(c *RedfishClientConfig) {
+					c.DialTimeout = 30 * time.Second
+				}),
+			},
+		},
+		"REDFISH_CLIENT_BASIC_AUTH overrides redfish_client.basic_auth": {
+			inputYAML: `loglevel: info`,
+			envVars:   map[string]string{"REDFISH_CLIENT_BASIC_AUTH": "true"},
+			wantConfig: &Config{
+				Loglevel:        "info",
+				ShutdownTimeout: 60 * time.Second,
+				RedfishClient: redfishConfigWith(func(c *RedfishClientConfig) {
+					c.BasicAuth = true
+				}),
+			},
+		},
+		"REDFISH_CLIENT_LOGOUT_TIMEOUT overrides redfish_client.logout_timeout": {
+			inputYAML: `loglevel: info`,
+			envVars:   map[string]string{"REDFISH_CLIENT_LOGOUT_TIMEOUT": "3s"},
+			wantConfig: &Config{
+				Loglevel:        "info",
+				ShutdownTimeout: 60 * time.Second,
+				RedfishClient: redfishConfigWith(func(c *RedfishClientConfig) {
+					c.LogoutTimeout = 3 * time.Second
+				}),
+			},
+		},
+		"REDFISH_CLIENT_RESPONSE_HEADER_TIMEOUT overrides redfish_client.response_header_timeout": {
+			inputYAML: `loglevel: info`,
+			envVars:   map[string]string{"REDFISH_CLIENT_RESPONSE_HEADER_TIMEOUT": "15s"},
+			wantConfig: &Config{
+				Loglevel:        "info",
+				ShutdownTimeout: 60 * time.Second,
+				RedfishClient: redfishConfigWith(func(c *RedfishClientConfig) {
+					c.ResponseHeaderTimeout = 15 * time.Second
+				}),
 			},
 		},
 		"prefix MYPREFIX applies to all env vars": {


### PR DESCRIPTION
# Release Redfish sessions on every scrape path

## Bug

BMCs cap concurrent Redfish sessions (~10) and refuse all new ones once full — presenting as immediate 503 or `Base.1.x.SessionLimitExceeded` on devices that are otherwise perfectly reachable. The exporter opens a session per scrape and leaked them two ways:

1. `Collect()` deferred `Logout()` only inside its `else` branch. When the scrape context was already cancelled, it logged "skipping further collection" and returned with the session still open. 1,204 events/24h in iad02.
2. Teardown was unbounded. gofish's `Logout()` swaps a cancelled context for `context.Background()`, and our `http.Client` set only `DialTimeout` and `TLSHandshakeTimeout` — no `Timeout`, no `ResponseHeaderTimeout`. On a BMC that completes TCP+TLS and then never answers, that DELETE blocks forever, holding the handler goroutine and the session with it.

## Changes

- Teardown moved out of `Collect()` into an idempotent `Close()`, deferred by the handler as soon as the collector is built — so it also covers the cancelled-context branch, a `MustRegister` panic, and any path where `Collect()` never runs. 
- `Close()` issues the DELETE on `context.WithoutCancel` with its own `logout_timeout` (10s). Detached because the scrape context is usually already dead by then, which is the leaking case.
- `ResponseHeaderTimeout` (30s) on the transport, so nothing waits on a silent BMC forever.
- `Close()` calls `Service.DeleteSession` directly — gofish's `Logout()` discards the error, which is why failed teardowns were invisible.
- New `basic_auth` option (default off): gofish then skips `CreateSession` entirely, so the exporter consumes **zero** session slots.
- New per-target metrics: `redfish_exporter_sessions_abandoned_total{target}` and `redfish_exporter_session_logouts_total{target,result}`. The existing HTTP-level DELETE metric labels the exporter pod, not the BMC, so per-device leaks were unmeasurable.

12 new tests drive a fake BMC that counts open session slots.