### PR TITLE
attempt 2 at fixing session handling

### DIFF
--- a/cmd/redfish-exporter/main.go
+++ b/cmd/redfish-exporter/main.go
@@ -103,6 +103,7 @@ func registerMetaMetrics() {
 		collectorModuleUnknown,
 		scrapeSuccessesTotal,
 	}
+	custom = append(custom, collector.SessionMetrics()...)
 
 	prometheus.DefaultRegisterer.MustRegister(custom...)
 }
@@ -213,6 +214,12 @@ func metricsHandler() http.HandlerFunc {
 			http.Error(w, fmt.Sprintf("unable to construct aggregate collector: %s", err), statusCode)
 			return
 		}
+		// NewRedfishCollector has opened a session on the BMC, so release it on every exit
+		// from here on: the normal path, the one where the scrape context is already
+		// cancelled and Collect() declines to do any work, and a panic unwinding out of
+		// MustRegister or a sub-collector. A session left behind occupies one of the BMC's
+		// limited slots until the BMC's own idle timeout reclaims it.
+		defer aggregateCollector.Close()
 
 		collectors := buildCollectorsFor(r.Context(), sr.Modules, safeConfig.GetModules(), aggregateCollector.Client(), scrapeLogger)
 		aggregateCollector.WithCollectors(collectors)

--- a/config.example.yml
+++ b/config.example.yml
@@ -12,6 +12,22 @@ groups:
 # loglevel can be one of "debug", "info", "warn", "error"
 loglevel: info
 
+# Tuning for the Redfish (gofish) client. Every value here is the default; the whole block
+# may be omitted. See docs/CONFIGURATION.md for detail.
+redfish_client:
+  # Maximum concurrent HTTP requests per scrape, per target.
+  max_concurrent_requests: 1
+  # Bounds TCP connect and the TLS handshake.
+  dial_timeout: 10s
+  # Bounds the wait for response headers once a request has been written, so a BMC that
+  # connects and then goes silent cannot hold a request open indefinitely. Raise this only
+  # for a BMC that is legitimately slow to answer.
+  response_header_timeout: 30s
+  # Bounds the session delete at the end of a scrape. That request runs on a context
+  # detached from the scrape's, which is usually already cancelled by then, so it needs a
+  # deadline of its own.
+  logout_timeout: 10s
+
 # The modules map defines various collectors the exporter may use, at client discretion.
 # Clients like Prometheus should specify one or more 'modules' HTTP query parameters
 # for each scrape, mapping to one or more of the defined modules below.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -52,7 +52,7 @@ Both fall back to the defaults above when set to zero, so a config file predatin
 ### Observing session teardown
 
 ```
-# HELP redfish_exporter_session_logouts_total Redfish session teardown attempts by target and outcome. result=failure means the session slot stays occupied on the BMC until its own idle timeout reclaims it.
+# HELP redfish_exporter_session_logouts_total Redfish session teardown attempts by target and outcome. result=failure means the session slot may stay occupied on the BMC until its own idle timeout reclaims it.
 # TYPE redfish_exporter_session_logouts_total counter
 ```
 
@@ -637,4 +637,4 @@ Maybe a good automation target? Until then, for a given `${TARGET}` representing
 
 ```shell
 curl -s "http://localhost:9610/redfish?target=${TARGET}&module=${MODULE}" | awk '/^# (TYPE|HELP)/ { if (/^# TYPE/) {print; print ""} else {print} }'
-``` 
+```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -13,6 +13,7 @@ hosts:
 groups:
   [ <string>: <hostdetail> ]
 modules: [ <string>: <module> ]
+[ redfish_client: <redfish_client> ]
 ```
 
 ## `<hostdetail>`
@@ -22,6 +23,44 @@ password: <string>
 ```
 
 Note that the `default` entry above is useful in order to avoid the exporter failing when attempting to collect from a host not explicitly defined in `hosts`.
+
+## `<redfish_client>`
+
+Tuning for the underlying Redfish (gofish) client. Every key is optional and shown with its default.
+
+``` yaml
+[ max_concurrent_requests: <int> | default = 1 ]
+[ dial_timeout: <timeout> | default = 10s ]
+[ response_header_timeout: <timeout> | default = 30s ]
+[ logout_timeout: <timeout> | default = 10s ]
+```
+
+Any key may also be set from the environment as `REDFISH_CLIENT_<KEY>`, prefixed further if `--config.env-prefix` is given — e.g. `REDFISH_CLIENT_LOGOUT_TIMEOUT=5s`.
+
+### Timeouts and session teardown
+
+The exporter opens one Redfish session per scrape request and deletes it when the request finishes. BMCs limit how many sessions may be open at once, and refuse new ones once that limit is reached, so a session that is not released denies service to later scrapes until the BMC's own idle timeout reclaims the slot. The two timeouts below exist to keep that from happening.
+
+`response_header_timeout` bounds how long a request waits for response headers after it has been written. Without it, the scrape's context is the only limit on any request, so a BMC that completes TCP and TLS and then declines to answer holds the request open for as long as it stays silent. It deliberately bounds only the wait for headers, so a slow but progressing response body is unaffected.
+
+Set it below the scrape timeout of whatever is calling `/redfish`, or it will not take effect: the scrape context is cancelled first and that becomes the operative limit. Its purpose is to cap how much of a scrape's budget any *single* stalled request can consume — which matters most at `max_concurrent_requests: 1`, where requests are issued one at a time and one stalled call would otherwise spend the remainder of the budget on its own.
+
+`logout_timeout` bounds the session delete issued at the end of a scrape. That request runs on a context deliberately detached from the scrape's: by the time teardown happens the scrape context is frequently already cancelled — which is exactly the case where a session would otherwise be stranded — and a cancelled context cannot carry the request that cleans up after it. Detached, it needs a deadline of its own.
+
+Both fall back to the defaults above when set to zero, so a config file predating these keys cannot leave a request unbounded.
+
+### Observing session teardown
+
+```
+# HELP redfish_exporter_session_logouts_total Redfish session teardown attempts by target and outcome. result=failure means the session slot stays occupied on the BMC until its own idle timeout reclaims it.
+# TYPE redfish_exporter_session_logouts_total counter
+```
+
+Exposed on `/metrics`, not on `/redfish`, because teardown happens after a scrape's response has already been written. Labels are `target` (the BMC address) and `result` (`success` or `failure`). It is labelled per device because a session limit is a per-device property; the `http.client.*` metrics cannot answer "which BMC is holding sessions we failed to release", since they identify the exporter rather than the target.
+
+A rising `result="failure"` rate for a target means sessions are accumulating on that BMC. Read it against `result="success"` for the same target to get a rate rather than a bare count.
+
+**Known limitation.** If a session creation reaches the BMC but the exporter stops waiting before reading the response, the BMC may create a session whose identifier arrives in a response header the exporter never read. Nothing can delete that session, and it is not counted by the metric above, because no teardown is ever attempted for it. It is released by the BMC's own idle timeout.
 
 ## `<module>`
 Users of `blackbox_exporter` will be familiar with the concept of [modules (aka probers)](https://github.com/prometheus/blackbox_exporter/blob/master/CONFIGURATION.md#module).

--- a/internal/collector/redfish_collector.go
+++ b/internal/collector/redfish_collector.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -43,6 +44,24 @@ var (
 	)
 )
 
+// sessionLogoutsTotal counts session teardown attempts. It is labelled by BMC address
+// because a session cap is a per-device limit, so "which device is holding sessions we
+// failed to release" is the only useful form of the question. The HTTP-level metrics from
+// otelhttp cannot answer it: they label the exporter instance, not the target.
+//
+// Teardown happens after the scrape response has already been gathered and written, so this
+// cannot live on the per-scrape registry — it is registered on the default registerer and
+// exposed on /metrics.
+var sessionLogoutsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name: prometheus.BuildFQName(namespace, exporter, "session_logouts_total"),
+	Help: "Redfish session teardown attempts by target and outcome. result=failure means the session slot stays occupied on the BMC until its own idle timeout reclaims it.",
+}, []string{"target", "result"})
+
+// SessionMetrics returns the session-lifecycle metrics for the caller to register.
+func SessionMetrics() []prometheus.Collector {
+	return []prometheus.Collector{sessionLogoutsTotal}
+}
+
 // redfishCollector is an aggregation of various other prometheus.Collector.
 // It implements prometheus.Collector, and at Describe or Collect time will iterate all of
 // its own collectors to yield data.
@@ -61,6 +80,13 @@ type redfishCollector struct {
 	// ones.
 	collectorsSucceeded atomic.Int64
 	collectorsFailed    atomic.Int64
+
+	// host is the BMC address, retained so Close() can attribute its outcome to a device.
+	host string
+	// logoutTimeout bounds the session delete in Close().
+	logoutTimeout time.Duration
+	// closeOnce guards the session teardown in Close().
+	closeOnce sync.Once
 }
 
 // NewRedfishCollector returns a *redfishCollector or an error.
@@ -70,10 +96,17 @@ func NewRedfishCollector(ctx context.Context, logger *slog.Logger, host string, 
 		return nil, err
 	}
 
+	logoutTimeout := rfConfig.LogoutTimeout
+	if logoutTimeout <= 0 {
+		logoutTimeout = config.DefaultRedfishConfig.LogoutTimeout
+	}
+
 	return &redfishCollector{
 		ctx:           ctx,
 		logger:        logger,
 		redfishClient: redfishClient,
+		host:          host,
+		logoutTimeout: logoutTimeout,
 		redfishUp: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
@@ -100,6 +133,60 @@ func (r *redfishCollector) Client() *gofish.APIClient {
 	return r.redfishClient
 }
 
+// Close releases the Redfish session opened by NewRedfishCollector. It is idempotent and
+// safe to call on a collector whose Collect() never ran.
+//
+// Session teardown belongs to whoever caused the session to be created, which is the scrape
+// handler, not Collect(). BMCs cap concurrent sessions and refuse every new one once the cap
+// is reached, so a session that outlives its scrape denies service to later scrapes until the
+// BMC's own idle timeout reclaims the slot. Callers should defer Close() as soon as the
+// collector is constructed: a deferred call also runs while a panic unwinds, so it covers the
+// paths where Collect() is never reached or does no work.
+//
+// The delete runs on a context detached from the scrape's. By the time Close() is reached the
+// scrape context is frequently already cancelled — that is precisely the case that leaks — and
+// a cancelled context cannot carry the request that cleans up after it. Detaching keeps the
+// scrape's context values, so the collector attribute on the HTTP metrics survives, while
+// dropping its cancellation. The replacement carries its own deadline: gofish's Logout()
+// substitutes context.Background() for a cancelled context, which would otherwise leave this
+// request with no limit at all and park the handler goroutine on a silent BMC.
+func (r *redfishCollector) Close() {
+	// A double DELETE would target a slot the BMC may have already reissued, hence the once.
+	r.closeOnce.Do(func() {
+		if r.redfishClient == nil {
+			return
+		}
+		session, err := r.redfishClient.GetSession()
+		if err != nil {
+			// No session was established, so there is nothing to release.
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(r.ctx), r.logoutTimeout)
+		defer cancel()
+
+		// Operate on a WithContext copy rather than on the client itself: the copy shares the
+		// auth pointer, so the session is still identified correctly, but no field of a client
+		// that other goroutines may still be reading gets mutated.
+		api := r.redfishClient.WithContext(ctx)
+		// gofish's Logout() does this for us; since we bypass it, close the idle connections
+		// the keepalive settings would otherwise hold for up to a minute after the scrape.
+		defer api.HTTPClient.CloseIdleConnections()
+
+		// DeleteSession is called directly rather than through gofish's Logout(), which
+		// discards the returned error and so makes a failed teardown indistinguishable from
+		// a successful one.
+		if err := api.Service.DeleteSession(session.ID); err != nil {
+			sessionLogoutsTotal.WithLabelValues(r.host, "failure").Inc()
+			r.logger.Error("failed to delete redfish session; the slot stays occupied on the BMC until its own idle timeout reclaims it",
+				slog.String("session", session.ID),
+				slog.Any("error", err))
+			return
+		}
+		sessionLogoutsTotal.WithLabelValues(r.host, "success").Inc()
+	})
+}
+
 // Describe implements prometheus.Collector.
 func (r *redfishCollector) Describe(ch chan<- *prometheus.Desc) {
 	for _, collector := range r.collectors {
@@ -120,7 +207,8 @@ func (r *redfishCollector) Collect(ch chan<- prometheus.Metric) {
 		r.redfishUp.Set(0)
 	} else {
 		r.redfishUp.Set(1)
-		defer r.redfishClient.Logout()
+		// Session teardown is the caller's responsibility via Close(), so that it also
+		// happens on the branch above and on paths where Collect() is never reached.
 		eg := newRecoverGroup(r.ctx)
 		for _, collector := range r.collectors {
 			eg.Go(func() error {
@@ -165,16 +253,27 @@ func newRedfishClient(ctx context.Context, host string, username string, passwor
 		KeepAlive: 30 * time.Second,
 	}
 
+	responseHeaderTimeout := rfConfig.ResponseHeaderTimeout
+	if responseHeaderTimeout <= 0 {
+		responseHeaderTimeout = config.DefaultRedfishConfig.ResponseHeaderTimeout
+	}
+
 	transport := &http.Transport{
 		DialContext:         dialer.DialContext,
 		TLSHandshakeTimeout: rfConfig.DialTimeout,
+		// The common BMC failure here is reachable-but-silent: TCP and TLS complete and the
+		// response headers never arrive. This bounds only the wait for headers, so a slow
+		// but progressing response body is left alone. gofish does not overwrite this field,
+		// and the otelhttp wrapper installed below sits outside this transport, so it applies
+		// to every request the client makes.
+		ResponseHeaderTimeout: responseHeaderTimeout,
 	}
 
 	client := &http.Client{
 		Transport: transport,
 	}
 
-	config := gofish.ClientConfig{
+	clientConfig := gofish.ClientConfig{
 		HTTPClient:            client,
 		MaxConcurrentRequests: rfConfig.MaxConcurrentRequests,
 		Endpoint:              url,
@@ -183,7 +282,7 @@ func newRedfishClient(ctx context.Context, host string, username string, passwor
 		Insecure:              true,
 		ReuseConnections:      true, // Enable HTTP keepalive for connection reuse
 	}
-	redfishClient, err := gofish.ConnectContext(ctx, config)
+	redfishClient, err := gofish.ConnectContext(ctx, clientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/collector/redfish_collector.go
+++ b/internal/collector/redfish_collector.go
@@ -54,7 +54,7 @@ var (
 // exposed on /metrics.
 var sessionLogoutsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Name: prometheus.BuildFQName(namespace, exporter, "session_logouts_total"),
-	Help: "Redfish session teardown attempts by target and outcome. result=failure means the session slot stays occupied on the BMC until its own idle timeout reclaims it.",
+	Help: "Redfish session teardown attempts by target and outcome. result=failure means the session slot may stay occupied on the BMC until its own idle timeout reclaims it.",
 }, []string{"target", "result"})
 
 // SessionMetrics returns the session-lifecycle metrics for the caller to register.

--- a/internal/collector/session_test.go
+++ b/internal/collector/session_test.go
@@ -1,0 +1,448 @@
+package collector
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/LambdaLabs/redfish_exporter/internal/config"
+)
+
+// sessionBMC is a fake Redfish endpoint implementing the session service, which tracks how
+// many session slots are currently occupied. Slot accounting is the assertion that matters
+// for session-lifecycle tests: a BMC caps concurrent sessions and refuses every new one once
+// the cap is reached, so the question is always "did the slot come back".
+type sessionBMC struct {
+	*httptest.Server
+
+	mu      sync.Mutex
+	open    map[string]bool
+	created int
+	deleted int
+
+	// refuseDeletes makes the session service answer a DELETE with 503, as a BMC at its
+	// session cap does. The slot stays occupied.
+	refuseDeletes bool
+
+	// stall, when non-nil, holds a handler until the channel is closed, after that handler
+	// has already applied its side effect. It reproduces a BMC that accepts a request and
+	// then never answers it — the failure mode both bounds in this change exist for.
+	stall chan struct{}
+}
+
+// stallHandlers makes every handler block until test cleanup, so the BMC accepts requests
+// and returns no response headers.
+func (b *sessionBMC) stallHandlers(t *testing.T) {
+	t.Helper()
+	stall := make(chan struct{})
+	b.mu.Lock()
+	b.stall = stall
+	b.mu.Unlock()
+	// Released at cleanup so the test server can shut down instead of waiting on the handler.
+	t.Cleanup(func() { close(stall) })
+}
+
+func (b *sessionBMC) waitIfStalled() {
+	b.mu.Lock()
+	stall := b.stall
+	b.mu.Unlock()
+	if stall != nil {
+		<-stall
+	}
+}
+
+func newSessionBMC(t *testing.T) *sessionBMC {
+	t.Helper()
+
+	b := &sessionBMC{open: make(map[string]bool)}
+	writeJSON := func(w http.ResponseWriter, body any) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(body))
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/redfish/v1/", func(w http.ResponseWriter, _ *http.Request) {
+		b.waitIfStalled()
+		writeJSON(w, map[string]any{
+			"@odata.id":      "/redfish/v1/",
+			"@odata.type":    "#ServiceRoot.v1_15_0.ServiceRoot",
+			"Id":             "RootService",
+			"RedfishVersion": "1.15.0",
+			"Links": map[string]any{
+				"Sessions": map[string]string{"@odata.id": "/redfish/v1/SessionService/Sessions"},
+			},
+		})
+	})
+
+	mux.HandleFunc("/redfish/v1/SessionService/Sessions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		b.mu.Lock()
+		b.created++
+		uri := fmt.Sprintf("/redfish/v1/SessionService/Sessions/%d", b.created)
+		b.open[uri] = true
+		b.mu.Unlock()
+
+		w.Header().Set("Location", uri)
+		w.Header().Set("X-Auth-Token", "token")
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mux.HandleFunc("/redfish/v1/SessionService/Sessions/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		b.mu.Lock()
+		b.deleted++
+		refused := b.refuseDeletes
+		if !refused {
+			delete(b.open, r.URL.Path)
+		}
+		b.mu.Unlock()
+
+		b.waitIfStalled()
+		if refused {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// TLS, so tests exercise the real newRedfishClient path, which builds an https://
+	// endpoint and relies on the client's Insecure setting for the BMCs' self-signed certs.
+	b.Server = httptest.NewTLSServer(mux)
+	t.Cleanup(b.Close)
+	return b
+}
+
+func (b *sessionBMC) counts() (openSlots, created, deleted int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.open), b.created, b.deleted
+}
+
+func (b *sessionBMC) host(t *testing.T) string {
+	t.Helper()
+	u, err := url.Parse(b.URL)
+	require.NoError(t, err)
+	return u.Host
+}
+
+func testRedfishConfig() config.RedfishClientConfig {
+	return config.RedfishClientConfig{
+		MaxConcurrentRequests: 1,
+		DialTimeout:           2 * time.Second,
+		ResponseHeaderTimeout: 5 * time.Second,
+		LogoutTimeout:         2 * time.Second,
+	}
+}
+
+// newBMCCollector builds a redfishCollector against the fake BMC via the exporter's own
+// constructor, so the session is created exactly as it is in production.
+func newBMCCollector(t *testing.T, ctx context.Context, b *sessionBMC) *redfishCollector {
+	t.Helper()
+	return newBMCCollectorWithConfig(t, ctx, b, testRedfishConfig())
+}
+
+func newBMCCollectorWithConfig(t *testing.T, ctx context.Context, b *sessionBMC, cfg config.RedfishClientConfig) *redfishCollector {
+	t.Helper()
+	rc, err := NewRedfishCollector(ctx, NewTestLogger(t, 0), b.host(t), "user", "pass", cfg)
+	require.NoError(t, err)
+	return rc
+}
+
+// TestClose_ReleasesSessionWhenScrapeContextCancelled is the leak this change targets.
+// The session is opened against the inbound request's context, so when Prometheus abandons a
+// slow scrape that context is already cancelled by the time collection would start. Collect()
+// then takes its early-return branch, and teardown used to live only in the other branch —
+// so the slot stayed occupied until the BMC's own idle timeout reclaimed it.
+func TestClose_ReleasesSessionWhenScrapeContextCancelled(t *testing.T) {
+	bmc := newSessionBMC(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	rc := newBMCCollector(t, ctx, bmc)
+
+	openSlots, created, _ := bmc.counts()
+	require.Equal(t, 1, created, "constructing the collector opens exactly one session")
+	require.Equal(t, 1, openSlots)
+
+	// The scrape context dies before collection begins.
+	cancel()
+
+	ch := make(chan prometheus.Metric, 32)
+	rc.Collect(ch)
+
+	openSlots, _, deleted := bmc.counts()
+	require.Equal(t, 0, deleted, "Collect() no longer owns teardown")
+	require.Equal(t, 1, openSlots)
+
+	rc.Close()
+
+	openSlots, created, deleted = bmc.counts()
+	assert.Equal(t, 0, openSlots, "the slot must be returned to the BMC")
+	assert.Equal(t, 1, created)
+	assert.Equal(t, 1, deleted)
+}
+
+// TestClose_ReleasesSessionAfterCollect covers the ordinary path, confirming teardown still
+// happens now that it has moved out of Collect().
+func TestClose_ReleasesSessionAfterCollect(t *testing.T) {
+	bmc := newSessionBMC(t)
+	rc := newBMCCollector(t, context.Background(), bmc)
+	rc.WithCollectors([]ContextAwareCollector{&stubCollector{}})
+
+	ch := make(chan prometheus.Metric, 32)
+	rc.Collect(ch)
+	rc.Close()
+
+	openSlots, created, deleted := bmc.counts()
+	assert.Equal(t, 0, openSlots)
+	assert.Equal(t, 1, created)
+	assert.Equal(t, 1, deleted)
+}
+
+// TestClose_ReleasesSessionWhenCollectPanics is the other path the old placement missed.
+// A deferred Close() runs while the panic unwinds, which is why teardown belongs to the
+// caller rather than to Collect().
+func TestClose_ReleasesSessionWhenCollectPanics(t *testing.T) {
+	bmc := newSessionBMC(t)
+	rc := newBMCCollector(t, context.Background(), bmc)
+
+	func() {
+		defer func() {
+			_ = recover()
+		}()
+		defer rc.Close()
+		panic("simulated failure between construction and collection")
+	}()
+
+	openSlots, created, deleted := bmc.counts()
+	assert.Equal(t, 0, openSlots, "a panic must not strand the session")
+	assert.Equal(t, 1, created)
+	assert.Equal(t, 1, deleted)
+}
+
+// TestClose_Idempotent matters because a second DELETE would target a slot the BMC may have
+// already reissued to another client.
+func TestClose_Idempotent(t *testing.T) {
+	bmc := newSessionBMC(t)
+	rc := newBMCCollector(t, context.Background(), bmc)
+
+	rc.Close()
+	rc.Close()
+	rc.Close()
+
+	openSlots, _, deleted := bmc.counts()
+	assert.Equal(t, 0, openSlots)
+	assert.Equal(t, 1, deleted, "only the first Close() issues a DELETE")
+}
+
+// TestClose_NoClient guards the path where the collector never got a working client, so a
+// deferred Close() cannot turn a failed scrape into a panic.
+func TestClose_NoClient(t *testing.T) {
+	rc := newTestRedfishCollector(nil)
+	assert.NotPanics(t, rc.Close)
+}
+
+// TestClose_BoundedWhenBMCGoesSilent is the second half of the leak. Teardown deliberately
+// runs on a context detached from the scrape's, and gofish's Logout() substitutes
+// context.Background() for a cancelled one, so without a deadline of its own the delete has
+// no limit at all: a BMC that accepts the DELETE and never answers would park the handler
+// goroutine and hold the session indefinitely, one goroutine per scrape, without bound.
+func TestClose_BoundedWhenBMCGoesSilent(t *testing.T) {
+	bmc := newSessionBMC(t)
+	cfg := testRedfishConfig()
+	cfg.LogoutTimeout = 250 * time.Millisecond
+
+	rc := newBMCCollectorWithConfig(t, context.Background(), bmc, cfg)
+
+	// Only stall once the session exists, so construction succeeds and just the DELETE hangs.
+	bmc.stallHandlers(t)
+
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		rc.Close()
+		done <- time.Since(start)
+	}()
+
+	select {
+	case elapsed := <-done:
+		assert.Less(t, elapsed, 5*time.Second, "Close() must return on its own deadline")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close() blocked indefinitely on a silent BMC")
+	}
+}
+
+// TestClose_BoundedWhenScrapeContextCancelled pins the interaction between the two mechanisms:
+// the detached context is what lets the delete run at all after the scrape is cancelled, and
+// the deadline is what stops that detached request from running forever.
+func TestClose_BoundedWhenScrapeContextCancelled(t *testing.T) {
+	bmc := newSessionBMC(t)
+	cfg := testRedfishConfig()
+	cfg.LogoutTimeout = 250 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rc := newBMCCollectorWithConfig(t, ctx, bmc, cfg)
+	bmc.stallHandlers(t)
+	cancel()
+
+	start := time.Now()
+	rc.Close()
+	elapsed := time.Since(start)
+
+	assert.Greater(t, elapsed, 100*time.Millisecond,
+		"a cancelled scrape context must not short-circuit the delete; it should have been attempted")
+	assert.Less(t, elapsed, 5*time.Second, "and it must still be bounded by LogoutTimeout")
+
+	_, _, deleted := bmc.counts()
+	assert.Equal(t, 1, deleted, "the BMC should have received the DELETE")
+}
+
+// TestNewRedfishCollector_ZeroTimeoutsFallBackToBounded confirms a config predating these
+// fields cannot mean "no limit". A zero must resolve to the package default, not to infinity.
+func TestNewRedfishCollector_ZeroTimeoutsFallBackToBounded(t *testing.T) {
+	assert.Positive(t, config.DefaultRedfishConfig.LogoutTimeout)
+	assert.Positive(t, config.DefaultRedfishConfig.ResponseHeaderTimeout)
+
+	bmc := newSessionBMC(t)
+	rc := newBMCCollectorWithConfig(t, context.Background(), bmc, config.RedfishClientConfig{
+		MaxConcurrentRequests: 1,
+		DialTimeout:           2 * time.Second,
+	})
+
+	assert.Equal(t, config.DefaultRedfishConfig.LogoutTimeout, rc.logoutTimeout)
+
+	rc.Close()
+	openSlots, _, _ := bmc.counts()
+	assert.Equal(t, 0, openSlots)
+}
+
+// TestResponseHeaderTimeout_BoundsASilentBMC covers the other bound. The scrape context is
+// normally what limits a data request, but it only fires when Prometheus gives up or the
+// connection drops; a BMC that completes TCP and TLS and then says nothing needs a limit at
+// the transport. Construction is the cheapest place to observe it, since the service-root GET
+// is the first request the client makes.
+func TestResponseHeaderTimeout_BoundsASilentBMC(t *testing.T) {
+	bmc := newSessionBMC(t)
+	bmc.stallHandlers(t)
+
+	cfg := testRedfishConfig()
+	cfg.ResponseHeaderTimeout = 250 * time.Millisecond
+
+	start := time.Now()
+	_, err := NewRedfishCollector(context.Background(), NewTestLogger(t, 0), bmc.host(t),
+		"user", "pass", cfg)
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a BMC that never sends headers must not be waited on forever")
+	assert.Less(t, elapsed, 5*time.Second, "the transport bound should have fired")
+
+	// Assert which bound fired. Without this the test would also pass on a dial or TLS
+	// failure, which would not demonstrate anything about ResponseHeaderTimeout.
+	var netErr net.Error
+	require.ErrorAs(t, err, &netErr)
+	assert.True(t, netErr.Timeout(), "expected a timeout, got %v", err)
+	assert.Contains(t, err.Error(), "timeout awaiting response headers",
+		"expected the transport's response-header bound specifically, got %v", err)
+}
+
+// logoutCount reads the counter for one target and outcome. Each test gets its own fake BMC
+// on a fresh port, so the target label isolates tests from each other on this package-level
+// metric.
+func logoutCount(t *testing.T, target, result string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(sessionLogoutsTotal.WithLabelValues(target, result))
+}
+
+// TestClose_CountsSuccessfulTeardown gives the failure rate below a denominator; an
+// abandoned-session count is not interpretable without the total.
+func TestClose_CountsSuccessfulTeardown(t *testing.T) {
+	bmc := newSessionBMC(t)
+	target := bmc.host(t)
+	rc := newBMCCollector(t, context.Background(), bmc)
+
+	before := logoutCount(t, target, "success")
+	rc.Close()
+
+	assert.Equal(t, before+1, logoutCount(t, target, "success"))
+	assert.Equal(t, float64(0), logoutCount(t, target, "failure"))
+}
+
+// TestClose_CountsRefusedTeardown is the case gofish's Logout() hid entirely: it discards the
+// error from DeleteSession, so a BMC refusing the delete looked exactly like success. That
+// refusal is the interesting event, because the slot stays occupied.
+func TestClose_CountsRefusedTeardown(t *testing.T) {
+	bmc := newSessionBMC(t)
+	bmc.mu.Lock()
+	bmc.refuseDeletes = true
+	bmc.mu.Unlock()
+
+	target := bmc.host(t)
+	rc := newBMCCollector(t, context.Background(), bmc)
+
+	before := logoutCount(t, target, "failure")
+	rc.Close()
+
+	assert.Equal(t, before+1, logoutCount(t, target, "failure"),
+		"a refused teardown must be attributed to the target BMC")
+	assert.Equal(t, float64(0), logoutCount(t, target, "success"))
+
+	openSlots, _, deleted := bmc.counts()
+	assert.Equal(t, 1, deleted, "the DELETE was attempted")
+	assert.Equal(t, 1, openSlots, "and the BMC kept the slot")
+}
+
+// TestClose_CountsTimedOutTeardown checks the bound from Change 2 is also reported, rather
+// than being silently dropped as a non-event.
+func TestClose_CountsTimedOutTeardown(t *testing.T) {
+	bmc := newSessionBMC(t)
+	cfg := testRedfishConfig()
+	cfg.LogoutTimeout = 250 * time.Millisecond
+
+	target := bmc.host(t)
+	rc := newBMCCollectorWithConfig(t, context.Background(), bmc, cfg)
+	bmc.stallHandlers(t)
+
+	before := logoutCount(t, target, "failure")
+	rc.Close()
+
+	assert.Equal(t, before+1, logoutCount(t, target, "failure"))
+}
+
+// TestClose_CountsNothingWithoutASession keeps every recorded value meaningful: no client
+// means no session was ever created, so there is no teardown to report either way.
+func TestClose_CountsNothingWithoutASession(t *testing.T) {
+	rc := newTestRedfishCollector(nil)
+	rc.host = "no-client.test"
+
+	rc.Close()
+
+	assert.Equal(t, float64(0), logoutCount(t, "no-client.test", "success"))
+	assert.Equal(t, float64(0), logoutCount(t, "no-client.test", "failure"))
+}
+
+// TestSessionMetrics_Registers guards against a malformed or duplicate metric definition,
+// since registration in main() is fatal.
+func TestSessionMetrics_Registers(t *testing.T) {
+	require.NotEmpty(t, SessionMetrics())
+	reg := prometheus.NewRegistry()
+	for _, c := range SessionMetrics() {
+		assert.NoError(t, reg.Register(c))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,8 @@ var (
 	DefaultRedfishConfig = RedfishClientConfig{
 		MaxConcurrentRequests: 1,
 		DialTimeout:           10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		LogoutTimeout:         10 * time.Second,
 	}
 )
 
@@ -76,6 +78,8 @@ func newViperInstance(envPrefix string) *viper.Viper {
 	v.SetDefault("shutdown_timeout", 60*time.Second)
 	v.SetDefault("redfish_client.max_concurrent_requests", DefaultRedfishConfig.MaxConcurrentRequests)
 	v.SetDefault("redfish_client.dial_timeout", DefaultRedfishConfig.DialTimeout)
+	v.SetDefault("redfish_client.response_header_timeout", DefaultRedfishConfig.ResponseHeaderTimeout)
+	v.SetDefault("redfish_client.logout_timeout", DefaultRedfishConfig.LogoutTimeout)
 
 	return v
 }
@@ -151,6 +155,15 @@ type RedfishClientConfig struct {
 	// MaxConcurrentRequests sets the gofish client maximum permitted concurrent requests.
 	MaxConcurrentRequests int64         `mapstructure:"max_concurrent_requests"`
 	DialTimeout           time.Duration `mapstructure:"dial_timeout"`
+	// ResponseHeaderTimeout bounds the wait for a BMC's response headers after the request
+	// has been written. Without it the scrape context is the only limit on a request, so a
+	// BMC that completes TCP and TLS and then declines to answer holds the request open for
+	// as long as it stays silent.
+	ResponseHeaderTimeout time.Duration `mapstructure:"response_header_timeout"`
+	// LogoutTimeout bounds the session delete issued at the end of a scrape. That request
+	// runs on a context detached from the scrape's, which is typically already cancelled by
+	// then, so it needs a deadline of its own.
+	LogoutTimeout time.Duration `mapstructure:"logout_timeout"`
 }
 
 // Config represents the redfish_exporter config file

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -69,6 +69,8 @@ redfish_client:
 				RedfishClient: RedfishClientConfig{
 					MaxConcurrentRequests: 100,
 					DialTimeout:           10 * time.Second,
+					ResponseHeaderTimeout: 30 * time.Second,
+					LogoutTimeout:         10 * time.Second,
 				},
 			},
 		},
@@ -77,6 +79,8 @@ redfish_client:
 redfish_client:
   max_concurrent_requests: 100
   dial_timeout: 30s
+  response_header_timeout: 45s
+  logout_timeout: 5s
 `,
 			wantErrString: "",
 			wantConfig: &Config{
@@ -84,6 +88,8 @@ redfish_client:
 				RedfishClient: RedfishClientConfig{
 					MaxConcurrentRequests: 100,
 					DialTimeout:           30 * time.Second,
+					ResponseHeaderTimeout: 45 * time.Second,
+					LogoutTimeout:         5 * time.Second,
 				},
 			},
 		},
@@ -105,6 +111,8 @@ redfish_client:
 				RedfishClient: RedfishClientConfig{
 					MaxConcurrentRequests: 5,
 					DialTimeout:           10 * time.Second,
+					ResponseHeaderTimeout: 30 * time.Second,
+					LogoutTimeout:         10 * time.Second,
 				},
 			},
 		},
@@ -117,6 +125,36 @@ redfish_client:
 				RedfishClient: RedfishClientConfig{
 					MaxConcurrentRequests: 1,
 					DialTimeout:           30 * time.Second,
+					ResponseHeaderTimeout: 30 * time.Second,
+					LogoutTimeout:         10 * time.Second,
+				},
+			},
+		},
+		"REDFISH_CLIENT_LOGOUT_TIMEOUT overrides redfish_client.logout_timeout": {
+			inputYAML: `loglevel: info`,
+			envVars:   map[string]string{"REDFISH_CLIENT_LOGOUT_TIMEOUT": "3s"},
+			wantConfig: &Config{
+				Loglevel:        "info",
+				ShutdownTimeout: 60 * time.Second,
+				RedfishClient: RedfishClientConfig{
+					MaxConcurrentRequests: 1,
+					DialTimeout:           10 * time.Second,
+					ResponseHeaderTimeout: 30 * time.Second,
+					LogoutTimeout:         3 * time.Second,
+				},
+			},
+		},
+		"REDFISH_CLIENT_RESPONSE_HEADER_TIMEOUT overrides redfish_client.response_header_timeout": {
+			inputYAML: `loglevel: info`,
+			envVars:   map[string]string{"REDFISH_CLIENT_RESPONSE_HEADER_TIMEOUT": "15s"},
+			wantConfig: &Config{
+				Loglevel:        "info",
+				ShutdownTimeout: 60 * time.Second,
+				RedfishClient: RedfishClientConfig{
+					MaxConcurrentRequests: 1,
+					DialTimeout:           10 * time.Second,
+					ResponseHeaderTimeout: 15 * time.Second,
+					LogoutTimeout:         10 * time.Second,
 				},
 			},
 		},


### PR DESCRIPTION
  ## Bug

  The exporter opens one Redfish session per scrape and leaked them three ways. BMCs limit
  concurrent sessions and refuse new ones once full, so a stranded session denies service to
  later scrapes until the BMC's idle timeout reclaims the slot.

  1. **Teardown was in the wrong place.** The session is created by the handler
     (`main.go:201`) but deleted inside one branch of `Collect()`. When the scrape context was
     already cancelled, `Collect()` logged "skipping further collection" and returned with the
     session open — 1,204 events/24h in iad02. A panic out of `MustRegister` leaked it too.
  2. **Teardown was unbounded.** gofish's `Logout()` swaps `context.Background()` in for a
     cancelled context, and our `http.Client` set only `DialTimeout`/`TLSHandshakeTimeout` — no
     `Timeout`, no `ResponseHeaderTimeout`. Against a BMC that completes TCP+TLS then goes
     silent, that DELETE had no limit at all and parked the handler goroutine indefinitely.
  3. **Failures were invisible.** `Logout()` discards `DeleteSession`'s error, so a BMC refusing
     the delete looked identical to success.

  ## Changes

  - Teardown moves to an idempotent `Close()`, deferred by the handler right after
    construction. One `defer` covers all three paths — deferred calls also run during panic
    unwinding. `sync.Once` prevents a second DELETE hitting a reissued slot.
  - `Close()` runs the DELETE on `context.WithoutCancel(scrapeCtx)` + `logout_timeout` (10s),
    via a `WithContext` copy so no live client field is mutated. Detached because the scrape
    context is dead exactly when the DELETE is needed; deadlined because gofish's `Background`
    substitution otherwise leaves it unlimited.
  - `Close()` calls `Service.DeleteSession` directly and reports the outcome via
    `redfish_exporter_session_logouts_total{target,result}` on `/metrics`. Labelled per BMC
    because a session limit is a per-device property.
  - New `response_header_timeout` (30s) on the transport, bounding the wait for headers only.
    Note it must be set below the caller's scrape timeout to have any effect.

  Request count per scrape is unchanged — no added round trips. The DELETE now happens after
  the response is written, so `scrape_duration_seconds` should drop slightly while
  `redfish_exporter_collector_duration_seconds` stays flat.